### PR TITLE
feat(cyper-axum): add WebSocket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/compio-rs/cyper"
 [workspace.dependencies]
 compio = { version = "0.18.0", default-features = false }
 compio-quic = "0.7.0"
+compio-ws = "0.3.1"
 cyper-core = { path = "./cyper-core", default-features = false, version = "0.8.0" }
 cyper-axum = { path = "./cyper-axum", default-features = false, version = "0.8.0" }
 socket2 = "0.6"

--- a/cyper-axum/Cargo.toml
+++ b/cyper-axum/Cargo.toml
@@ -35,5 +35,15 @@ tokio = { version = "1", features = ["sync"] }
 default = []
 enable_log = ["compio-log/enable_log"]
 http2 = ["axum/http2"]
+ws = ["axum/ws"]
 
 nightly = ["cyper-core/nightly"]
+
+[dev-dependencies]
+compio = { workspace = true, default-features = true, features = ["macros"] }
+compio-ws = "0.3"
+futures-channel = { workspace = true }
+
+[[test]]
+name = "ws"
+required-features = ["ws"]

--- a/cyper-axum/Cargo.toml
+++ b/cyper-axum/Cargo.toml
@@ -30,7 +30,7 @@ tower-service = { workspace = true }
 
 tokio = { version = "1", features = ["sync"] }
 
-tungstenite = { version = "0.28", default-features = false, optional = true }
+compio-ws = { workspace = true, optional = true }
 sha1 = { version = "0.10", optional = true }
 base64 = { version = "0.22", optional = true }
 
@@ -39,13 +39,13 @@ base64 = { version = "0.22", optional = true }
 default = []
 enable_log = ["compio-log/enable_log"]
 http2 = ["axum/http2"]
-ws = ["dep:tungstenite", "dep:sha1", "dep:base64"]
+ws = ["dep:compio-ws", "dep:sha1", "dep:base64"]
 
 nightly = ["cyper-core/nightly"]
 
 [dev-dependencies]
 compio = { workspace = true, default-features = true, features = ["macros"] }
-compio-ws = "0.3"
+compio-ws = { workspace = true }
 futures-channel = { workspace = true }
 
 [[test]]

--- a/cyper-axum/Cargo.toml
+++ b/cyper-axum/Cargo.toml
@@ -9,10 +9,6 @@ readme = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
 [dependencies]
 compio = { workspace = true, features = ["net", "time"] }
 compio-log = "0.1.0"
@@ -30,7 +26,6 @@ tower-service = { workspace = true }
 
 tokio = { version = "1", features = ["sync"] }
 
-compio-ws = { workspace = true, optional = true }
 sha1 = { version = "0.10", optional = true }
 base64 = { version = "0.22", optional = true }
 
@@ -39,13 +34,12 @@ base64 = { version = "0.22", optional = true }
 default = []
 enable_log = ["compio-log/enable_log"]
 http2 = ["axum/http2"]
-ws = ["dep:compio-ws", "dep:sha1", "dep:base64"]
+ws = ["compio/ws", "dep:sha1", "dep:base64"]
 
 nightly = ["cyper-core/nightly"]
 
 [dev-dependencies]
-compio = { workspace = true, default-features = true, features = ["macros"] }
-compio-ws = { workspace = true }
+compio = { workspace = true, default-features = true, features = ["macros", "ws"] }
 futures-channel = { workspace = true }
 
 [[test]]

--- a/cyper-axum/Cargo.toml
+++ b/cyper-axum/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { version = "0.22", optional = true }
 
 
 [features]
-default = ["ws"]
+default = []
 enable_log = ["compio-log/enable_log"]
 http2 = ["axum/http2"]
 ws = ["dep:tungstenite", "dep:sha1", "dep:base64"]

--- a/cyper-axum/Cargo.toml
+++ b/cyper-axum/Cargo.toml
@@ -30,12 +30,16 @@ tower-service = { workspace = true }
 
 tokio = { version = "1", features = ["sync"] }
 
+tungstenite = { version = "0.28", default-features = false, optional = true }
+sha1 = { version = "0.10", optional = true }
+base64 = { version = "0.22", optional = true }
+
 
 [features]
-default = []
+default = ["ws"]
 enable_log = ["compio-log/enable_log"]
 http2 = ["axum/http2"]
-ws = ["axum/ws"]
+ws = ["dep:tungstenite", "dep:sha1", "dep:base64"]
 
 nightly = ["cyper-core/nightly"]
 

--- a/cyper-axum/src/lib.rs
+++ b/cyper-axum/src/lib.rs
@@ -4,10 +4,8 @@
 //! for `axum::serve`. See [`axum`] crate for its usage.
 
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "ws")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub mod ws;
 
 use std::{

--- a/cyper-axum/src/lib.rs
+++ b/cyper-axum/src/lib.rs
@@ -6,6 +6,10 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+pub mod ws;
+
 use std::{
     convert::Infallible,
     fmt::Debug,

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -1,0 +1,1052 @@
+//! WebSocket support for cyper-axum.
+//!
+//! This module provides a [`WebSocketUpgrade`] extractor and [`WebSocket`] type
+//! that work with the compio runtime, as a replacement for `axum::extract::ws`
+//! which depends on tokio.
+//!
+//! # Example
+//!
+//! ```
+//! use axum::{Router, response::Response, routing::any};
+//! use cyper_axum::ws::{Message, WebSocket, WebSocketUpgrade};
+//!
+//! let app = Router::new().route("/ws", any(handler));
+//!
+//! async fn handler(ws: WebSocketUpgrade) -> Response {
+//!     ws.on_upgrade(handle_socket)
+//! }
+//!
+//! async fn handle_socket(mut socket: WebSocket) {
+//!     while let Some(msg) = socket.recv().await {
+//!         let msg = if let Ok(msg) = msg {
+//!             msg
+//!         } else {
+//!             return;
+//!         };
+//!
+//!         if socket.send(msg).await.is_err() {
+//!             return;
+//!         }
+//!     }
+//! }
+//! # let _: Router = app;
+//! ```
+
+use std::{
+    borrow::Cow,
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Poll, ready},
+};
+
+use axum_core::{body::Body, extract::FromRequestParts, response::Response};
+use hyper::{
+    Method, StatusCode, Version,
+    header::{self, HeaderMap, HeaderName, HeaderValue},
+    http::request::Parts,
+    rt::{Read as _, Write as _},
+    upgrade::Upgraded,
+};
+use send_wrapper::SendWrapper;
+use sha1::{Digest, Sha1};
+use tungstenite::{self as ts, protocol::WebSocketConfig};
+
+use self::rejection::*;
+
+// ===== UpgradedIo =====
+
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+const MAX_BUF_SIZE: usize = 64 * 1024 * 1024;
+
+/// Adapter that bridges `hyper::upgrade::Upgraded` (poll-based hyper::rt IO)
+/// to sync `Read + Write` with internal buffers, suitable for tungstenite.
+struct UpgradedIo {
+    upgraded: Upgraded,
+    read_buf: Vec<u8>,
+    read_pos: usize,
+    write_buf: Vec<u8>,
+}
+
+impl UpgradedIo {
+    fn new(upgraded: Upgraded) -> Self {
+        Self {
+            upgraded,
+            read_buf: Vec::with_capacity(DEFAULT_BUF_SIZE),
+            read_pos: 0,
+            write_buf: Vec::with_capacity(DEFAULT_BUF_SIZE),
+        }
+    }
+
+    fn available_read(&self) -> &[u8] {
+        &self.read_buf[self.read_pos..]
+    }
+
+    fn consume_read(&mut self, amt: usize) {
+        self.read_pos += amt;
+        if self.read_pos == self.read_buf.len() {
+            self.read_buf.clear();
+            self.read_pos = 0;
+            // Shrink if oversized
+            if self.read_buf.capacity() > DEFAULT_BUF_SIZE * 4 {
+                self.read_buf.shrink_to(DEFAULT_BUF_SIZE);
+            }
+        }
+    }
+
+    /// Fill read buffer by polling the upgraded connection.
+    async fn fill_read_buf(&mut self) -> io::Result<usize> {
+        // Compact: move unconsumed data to front
+        if self.read_pos > 0 {
+            self.read_buf.drain(..self.read_pos);
+            self.read_pos = 0;
+        }
+
+        // Ensure space
+        let current_len = self.read_buf.len();
+        if current_len >= MAX_BUF_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "read buffer size limit exceeded",
+            ));
+        }
+        let needed = DEFAULT_BUF_SIZE;
+        self.read_buf.reserve(needed);
+
+        let read = futures_util::future::poll_fn(|cx| {
+            // SAFETY: spare capacity is valid for writing
+            let spare = self.read_buf.spare_capacity_mut();
+            let mut buf = hyper::rt::ReadBuf::uninit(spare);
+            let filled_before = buf.filled().len();
+            ready!(Pin::new(&mut self.upgraded).poll_read(cx, buf.unfilled()))?;
+            let filled_after = buf.filled().len();
+            let n = filled_after - filled_before;
+            Poll::Ready(Ok::<_, io::Error>(n))
+        })
+        .await?;
+
+        // SAFETY: poll_read initialized `read` more bytes
+        unsafe {
+            self.read_buf.set_len(current_len + read);
+        }
+        Ok(read)
+    }
+
+    /// Flush write buffer to the upgraded connection.
+    async fn flush_write_buf(&mut self) -> io::Result<usize> {
+        let mut written_total = 0;
+        while written_total < self.write_buf.len() {
+            let written = futures_util::future::poll_fn(|cx| {
+                let buf = &self.write_buf[written_total..];
+                Pin::new(&mut self.upgraded).poll_write(cx, buf)
+            })
+            .await?;
+            if written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "write returned 0 bytes",
+                ));
+            }
+            written_total += written;
+        }
+        self.write_buf.clear();
+        if self.write_buf.capacity() > DEFAULT_BUF_SIZE * 4 {
+            self.write_buf.shrink_to(DEFAULT_BUF_SIZE);
+        }
+
+        // Also flush the underlying stream
+        futures_util::future::poll_fn(|cx| Pin::new(&mut self.upgraded).poll_flush(cx)).await?;
+
+        Ok(written_total)
+    }
+}
+
+impl io::Read for UpgradedIo {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let available = self.available_read();
+        if available.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "need to fill read buffer",
+            ));
+        }
+        let to_read = available.len().min(buf.len());
+        buf[..to_read].copy_from_slice(&available[..to_read]);
+        self.consume_read(to_read);
+        Ok(to_read)
+    }
+}
+
+impl io::Write for UpgradedIo {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.write_buf.len() + buf.len() > MAX_BUF_SIZE {
+            let space = MAX_BUF_SIZE - self.write_buf.len();
+            if space == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "write buffer full, need to flush",
+                ));
+            }
+            self.write_buf.extend_from_slice(&buf[..space]);
+            return Ok(space);
+        }
+        self.write_buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Intentionally no-op for tungstenite compatibility.
+        // Actual flushing happens via flush_write_buf().
+        Ok(())
+    }
+}
+
+// ===== Message types =====
+
+/// UTF-8 wrapper for [ts::Bytes].
+///
+/// An [`Utf8Bytes`] is always guaranteed to contain valid UTF-8.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Utf8Bytes(ts::Utf8Bytes);
+
+impl Utf8Bytes {
+    /// Creates from a static str.
+    #[inline]
+    #[must_use]
+    pub const fn from_static(str: &'static str) -> Self {
+        Self(ts::Utf8Bytes::from_static(str))
+    }
+
+    /// Returns as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    fn into_tungstenite(self) -> ts::Utf8Bytes {
+        self.0
+    }
+}
+
+impl std::ops::Deref for Utf8Bytes {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for Utf8Bytes {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<ts::Bytes> for Utf8Bytes {
+    type Error = std::str::Utf8Error;
+
+    #[inline]
+    fn try_from(bytes: ts::Bytes) -> Result<Self, Self::Error> {
+        Ok(Self(bytes.try_into()?))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Utf8Bytes {
+    type Error = std::str::Utf8Error;
+
+    #[inline]
+    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(Self(v.try_into()?))
+    }
+}
+
+impl From<String> for Utf8Bytes {
+    #[inline]
+    fn from(s: String) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&str> for Utf8Bytes {
+    #[inline]
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&String> for Utf8Bytes {
+    #[inline]
+    fn from(s: &String) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<Utf8Bytes> for ts::Bytes {
+    #[inline]
+    fn from(Utf8Bytes(bytes): Utf8Bytes) -> Self {
+        bytes.into()
+    }
+}
+
+impl<T> PartialEq<T> for Utf8Bytes
+where
+    for<'a> &'a str: PartialEq<T>,
+{
+    #[inline]
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == *other
+    }
+}
+
+/// Status code used to indicate why an endpoint is closing the WebSocket
+/// connection.
+pub type CloseCode = u16;
+
+/// A struct representing the close command.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CloseFrame {
+    /// The reason as a code.
+    pub code: CloseCode,
+    /// The reason as text string.
+    pub reason: Utf8Bytes,
+}
+
+/// A WebSocket message.
+// This code comes from https://github.com/snapview/tungstenite-rs/blob/master/src/protocol/message.rs and is under following license:
+// Copyright (c) 2017 Alexey Galakhov
+// Copyright (c) 2016 Jason Housley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Message {
+    /// A text WebSocket message
+    Text(Utf8Bytes),
+    /// A binary WebSocket message
+    Binary(ts::Bytes),
+    /// A ping message with the specified payload
+    ///
+    /// The payload here must have a length less than 125 bytes.
+    Ping(ts::Bytes),
+    /// A pong message with the specified payload
+    ///
+    /// The payload here must have a length less than 125 bytes.
+    Pong(ts::Bytes),
+    /// A close message with the optional close frame.
+    Close(Option<CloseFrame>),
+}
+
+impl Message {
+    fn into_tungstenite(self) -> ts::Message {
+        match self {
+            Self::Text(text) => ts::Message::Text(text.into_tungstenite()),
+            Self::Binary(binary) => ts::Message::Binary(binary),
+            Self::Ping(ping) => ts::Message::Ping(ping),
+            Self::Pong(pong) => ts::Message::Pong(pong),
+            Self::Close(Some(close)) => ts::Message::Close(Some(ts::protocol::CloseFrame {
+                code: ts::protocol::frame::coding::CloseCode::from(close.code),
+                reason: close.reason.into_tungstenite(),
+            })),
+            Self::Close(None) => ts::Message::Close(None),
+        }
+    }
+
+    fn from_tungstenite(message: ts::Message) -> Option<Self> {
+        match message {
+            ts::Message::Text(text) => Some(Self::Text(Utf8Bytes(text))),
+            ts::Message::Binary(binary) => Some(Self::Binary(binary)),
+            ts::Message::Ping(ping) => Some(Self::Ping(ping)),
+            ts::Message::Pong(pong) => Some(Self::Pong(pong)),
+            ts::Message::Close(Some(close)) => Some(Self::Close(Some(CloseFrame {
+                code: close.code.into(),
+                reason: Utf8Bytes(close.reason),
+            }))),
+            ts::Message::Close(None) => Some(Self::Close(None)),
+            // we can ignore `Frame` frames as recommended by the tungstenite maintainers
+            // https://github.com/snapview/tungstenite-rs/issues/268
+            ts::Message::Frame(_) => None,
+        }
+    }
+
+    /// Consume the WebSocket and return it as binary data.
+    pub fn into_data(self) -> ts::Bytes {
+        match self {
+            Self::Text(string) => ts::Bytes::from(string),
+            Self::Binary(data) | Self::Ping(data) | Self::Pong(data) => data,
+            Self::Close(None) => ts::Bytes::new(),
+            Self::Close(Some(frame)) => ts::Bytes::from(frame.reason),
+        }
+    }
+
+    /// Attempt to consume the WebSocket message and convert it to a
+    /// [`Utf8Bytes`].
+    pub fn into_text(self) -> Result<Utf8Bytes, axum_core::Error> {
+        match self {
+            Self::Text(string) => Ok(string),
+            Self::Binary(data) | Self::Ping(data) | Self::Pong(data) => {
+                Ok(Utf8Bytes::try_from(data).map_err(axum_core::Error::new)?)
+            }
+            Self::Close(None) => Ok(Utf8Bytes::default()),
+            Self::Close(Some(frame)) => Ok(frame.reason),
+        }
+    }
+
+    /// Attempt to get a &str from the WebSocket message,
+    /// this will try to convert binary data to utf8.
+    pub fn to_text(&self) -> Result<&str, axum_core::Error> {
+        match *self {
+            Self::Text(ref string) => Ok(string.as_str()),
+            Self::Binary(ref data) | Self::Ping(ref data) | Self::Pong(ref data) => {
+                Ok(std::str::from_utf8(data).map_err(axum_core::Error::new)?)
+            }
+            Self::Close(None) => Ok(""),
+            Self::Close(Some(ref frame)) => Ok(&frame.reason),
+        }
+    }
+
+    /// Create a new text WebSocket message from a stringable.
+    pub fn text<S>(string: S) -> Message
+    where
+        S: Into<Utf8Bytes>,
+    {
+        Message::Text(string.into())
+    }
+
+    /// Create a new binary WebSocket message by converting to `Bytes`.
+    pub fn binary<B>(bin: B) -> Message
+    where
+        B: Into<ts::Bytes>,
+    {
+        Message::Binary(bin.into())
+    }
+}
+
+impl From<String> for Message {
+    fn from(string: String) -> Self {
+        Message::Text(string.into())
+    }
+}
+
+impl<'s> From<&'s str> for Message {
+    fn from(string: &'s str) -> Self {
+        Message::Text(string.into())
+    }
+}
+
+impl<'b> From<&'b [u8]> for Message {
+    fn from(data: &'b [u8]) -> Self {
+        Message::Binary(ts::Bytes::copy_from_slice(data))
+    }
+}
+
+impl From<ts::Bytes> for Message {
+    fn from(data: ts::Bytes) -> Self {
+        Message::Binary(data)
+    }
+}
+
+impl From<Vec<u8>> for Message {
+    fn from(data: Vec<u8>) -> Self {
+        Message::Binary(data.into())
+    }
+}
+
+impl From<Message> for Vec<u8> {
+    fn from(msg: Message) -> Self {
+        msg.into_data().to_vec()
+    }
+}
+
+// ===== WebSocket =====
+
+/// A WebSocket stream.
+///
+/// Use [`recv`](Self::recv) and [`send`](Self::send) to communicate.
+#[derive(Debug)]
+pub struct WebSocket {
+    inner: ts::WebSocket<UpgradedIo>,
+    protocol: Option<HeaderValue>,
+}
+
+impl std::fmt::Debug for UpgradedIo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpgradedIo").finish_non_exhaustive()
+    }
+}
+
+impl WebSocket {
+    /// Receive another message.
+    ///
+    /// Returns `None` if the stream has closed.
+    pub async fn recv(&mut self) -> Option<Result<Message, axum_core::Error>> {
+        loop {
+            match self.inner.read() {
+                Ok(msg) => {
+                    // Flush any buffered writes (e.g. automatic pong replies)
+                    let _ = self.flush().await;
+                    if let Some(msg) = Message::from_tungstenite(msg) {
+                        return Some(Ok(msg));
+                    }
+                }
+                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
+                    // Need more data
+                    match self.inner.get_mut().fill_read_buf().await {
+                        Ok(0) => return None, // EOF
+                        Ok(_) => continue,
+                        Err(e) => return Some(Err(axum_core::Error::new(e))),
+                    }
+                }
+                Err(ts::Error::ConnectionClosed) => return None,
+                Err(ts::Error::AlreadyClosed) => return None,
+                Err(e) => {
+                    let _ = self.flush().await;
+                    return Some(Err(axum_core::Error::new(e)));
+                }
+            }
+        }
+    }
+
+    /// Send a message.
+    pub async fn send(&mut self, msg: Message) -> Result<(), axum_core::Error> {
+        loop {
+            match self.inner.send(msg.clone().into_tungstenite()) {
+                Ok(()) => break,
+                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
+                    self.inner
+                        .get_mut()
+                        .flush_write_buf()
+                        .await
+                        .map_err(axum_core::Error::new)?;
+                }
+                Err(e) => return Err(axum_core::Error::new(e)),
+            }
+        }
+        self.flush().await
+    }
+
+    /// Close the WebSocket connection.
+    pub async fn close(mut self, close_frame: Option<CloseFrame>) -> Result<(), axum_core::Error> {
+        let ts_frame = close_frame.map(|f| ts::protocol::CloseFrame {
+            code: ts::protocol::frame::coding::CloseCode::from(f.code),
+            reason: f.reason.into_tungstenite(),
+        });
+        loop {
+            match self.inner.close(ts_frame.clone()) {
+                Ok(()) => break,
+                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
+                    let io = self.inner.get_mut();
+                    let flushed = io.flush_write_buf().await.map_err(axum_core::Error::new)?;
+                    if flushed == 0 {
+                        io.fill_read_buf().await.map_err(axum_core::Error::new)?;
+                    }
+                }
+                Err(ts::Error::ConnectionClosed) => break,
+                Err(e) => return Err(axum_core::Error::new(e)),
+            }
+        }
+        self.flush().await
+    }
+
+    /// Return the selected WebSocket subprotocol, if one has been chosen.
+    pub fn protocol(&self) -> Option<&HeaderValue> {
+        self.protocol.as_ref()
+    }
+
+    async fn flush(&mut self) -> Result<(), axum_core::Error> {
+        loop {
+            match self.inner.flush() {
+                Ok(()) => break,
+                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
+                    self.inner
+                        .get_mut()
+                        .flush_write_buf()
+                        .await
+                        .map_err(axum_core::Error::new)?;
+                }
+                Err(ts::Error::ConnectionClosed) => break,
+                Err(e) => return Err(axum_core::Error::new(e)),
+            }
+        }
+        self.inner
+            .get_mut()
+            .flush_write_buf()
+            .await
+            .map_err(axum_core::Error::new)?;
+        Ok(())
+    }
+}
+
+// ===== OnFailedUpgrade =====
+
+/// What to do when a connection upgrade fails.
+///
+/// See [`WebSocketUpgrade::on_failed_upgrade`] for more details.
+pub trait OnFailedUpgrade: 'static {
+    /// Call the callback.
+    fn call(self, error: axum_core::Error);
+}
+
+impl<F> OnFailedUpgrade for F
+where
+    F: FnOnce(axum_core::Error) + 'static,
+{
+    fn call(self, error: axum_core::Error) {
+        self(error)
+    }
+}
+
+/// The default `OnFailedUpgrade` used by `WebSocketUpgrade`.
+///
+/// It simply ignores the error.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct DefaultOnFailedUpgrade;
+
+impl OnFailedUpgrade for DefaultOnFailedUpgrade {
+    #[inline]
+    fn call(self, _error: axum_core::Error) {}
+}
+
+// ===== WebSocketUpgrade =====
+
+/// Extractor for establishing WebSocket connections.
+///
+/// For HTTP/1.1 requests, this extractor requires the request method to be
+/// `GET`; in later versions, `CONNECT` is used instead. To support both, it
+/// should be used with [`any`](axum::routing::any).
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
+#[must_use]
+pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
+    config: WebSocketConfig,
+    protocol: Option<HeaderValue>,
+    sec_websocket_key: Option<HeaderValue>,
+    on_upgrade: hyper::upgrade::OnUpgrade,
+    on_failed_upgrade: F,
+    sec_websocket_protocol: Option<HeaderValue>,
+}
+
+impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocketUpgrade")
+            .field("config", &self.config)
+            .field("protocol", &self.protocol)
+            .field("sec_websocket_key", &self.sec_websocket_key)
+            .field("sec_websocket_protocol", &self.sec_websocket_protocol)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<F> WebSocketUpgrade<F> {
+    /// Read buffer capacity. The default value is 128KiB.
+    pub fn read_buffer_size(mut self, size: usize) -> Self {
+        self.config.read_buffer_size = size;
+        self
+    }
+
+    /// The target minimum size of the write buffer to reach before writing the
+    /// data to the underlying stream.
+    ///
+    /// The default value is 128 KiB.
+    pub fn write_buffer_size(mut self, size: usize) -> Self {
+        self.config.write_buffer_size = size;
+        self
+    }
+
+    /// The max size of the write buffer in bytes. Setting this can provide
+    /// backpressure in the case the write buffer is filling up due to write
+    /// errors.
+    ///
+    /// The default value is unlimited.
+    pub fn max_write_buffer_size(mut self, max: usize) -> Self {
+        self.config.max_write_buffer_size = max;
+        self
+    }
+
+    /// Set the maximum message size (defaults to 64 megabytes)
+    pub fn max_message_size(mut self, max: usize) -> Self {
+        self.config.max_message_size = Some(max);
+        self
+    }
+
+    /// Set the maximum frame size (defaults to 16 megabytes)
+    pub fn max_frame_size(mut self, max: usize) -> Self {
+        self.config.max_frame_size = Some(max);
+        self
+    }
+
+    /// Allow server to accept unmasked frames (defaults to false)
+    pub fn accept_unmasked_frames(mut self, accept: bool) -> Self {
+        self.config.accept_unmasked_frames = accept;
+        self
+    }
+
+    /// Set the known protocols.
+    ///
+    /// If the protocol name specified by `Sec-WebSocket-Protocol` header
+    /// to match any of them, the upgrade response will include
+    /// `Sec-WebSocket-Protocol` header and return the protocol name.
+    ///
+    /// The protocols should be listed in decreasing order of preference: if the
+    /// client offers multiple protocols that the server could support, the
+    /// server will pick the first one in this list.
+    pub fn protocols<I>(mut self, protocols: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<Cow<'static, str>>,
+    {
+        if let Some(req_protocols) = self
+            .sec_websocket_protocol
+            .as_ref()
+            .and_then(|p| p.to_str().ok())
+        {
+            self.protocol = protocols
+                .into_iter()
+                .map(Into::into)
+                .find(|protocol| {
+                    req_protocols
+                        .split(',')
+                        .any(|req_protocol| req_protocol.trim() == protocol.as_ref())
+                })
+                .map(|protocol| match protocol {
+                    Cow::Owned(s) => HeaderValue::from_str(&s).unwrap(),
+                    Cow::Borrowed(s) => HeaderValue::from_static(s),
+                });
+        }
+
+        self
+    }
+
+    /// Return the selected protocol after calling
+    /// [`protocols`](Self::protocols).
+    pub fn selected_protocol(&self) -> Option<&HeaderValue> {
+        self.protocol.as_ref()
+    }
+
+    /// Set a callback to be called if upgrading the connection fails.
+    pub fn on_failed_upgrade<C>(self, callback: C) -> WebSocketUpgrade<C>
+    where
+        C: OnFailedUpgrade,
+    {
+        WebSocketUpgrade {
+            config: self.config,
+            protocol: self.protocol,
+            sec_websocket_key: self.sec_websocket_key,
+            on_upgrade: self.on_upgrade,
+            on_failed_upgrade: callback,
+            sec_websocket_protocol: self.sec_websocket_protocol,
+        }
+    }
+
+    /// Finalize upgrading the connection and call the provided callback with
+    /// the stream.
+    pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
+    where
+        C: FnOnce(WebSocket) -> Fut + 'static,
+        Fut: Future<Output = ()> + 'static,
+        F: OnFailedUpgrade,
+    {
+        let on_upgrade = self.on_upgrade;
+        let config = self.config;
+        let on_failed_upgrade = self.on_failed_upgrade;
+        let protocol = self.protocol.clone();
+
+        compio::runtime::spawn(SendWrapper::new(async move {
+            let upgraded = match on_upgrade.await {
+                Ok(upgraded) => upgraded,
+                Err(err) => {
+                    on_failed_upgrade.call(axum_core::Error::new(err));
+                    return;
+                }
+            };
+
+            let io = UpgradedIo::new(upgraded);
+            let ws = ts::WebSocket::from_raw_socket(io, ts::protocol::Role::Server, Some(config));
+            let socket = WebSocket {
+                inner: ws,
+                protocol,
+            };
+            callback(socket).await;
+        }))
+        .detach();
+
+        let mut response = if let Some(sec_websocket_key) = &self.sec_websocket_key {
+            #[allow(clippy::declare_interior_mutable_const)]
+            const UPGRADE: HeaderValue = HeaderValue::from_static("upgrade");
+            #[allow(clippy::declare_interior_mutable_const)]
+            const WEBSOCKET: HeaderValue = HeaderValue::from_static("websocket");
+
+            Response::builder()
+                .status(StatusCode::SWITCHING_PROTOCOLS)
+                .header(header::CONNECTION, UPGRADE)
+                .header(header::UPGRADE, WEBSOCKET)
+                .header(
+                    header::SEC_WEBSOCKET_ACCEPT,
+                    sign(sec_websocket_key.as_bytes()),
+                )
+                .body(Body::empty())
+                .unwrap()
+        } else {
+            Response::new(Body::empty())
+        };
+
+        if let Some(protocol) = self.protocol {
+            response
+                .headers_mut()
+                .insert(header::SEC_WEBSOCKET_PROTOCOL, protocol);
+        }
+
+        response
+    }
+}
+
+// ===== FromRequestParts =====
+
+impl<S> FromRequestParts<S> for WebSocketUpgrade<DefaultOnFailedUpgrade>
+where
+    S: Send + Sync,
+{
+    type Rejection = WebSocketUpgradeRejection;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let sec_websocket_key = if parts.version <= Version::HTTP_11 {
+            if parts.method != Method::GET {
+                return Err(MethodNotGet.into());
+            }
+
+            if !header_contains(&parts.headers, header::CONNECTION, "upgrade") {
+                return Err(InvalidConnectionHeader.into());
+            }
+
+            if !header_eq(&parts.headers, header::UPGRADE, "websocket") {
+                return Err(InvalidUpgradeHeader.into());
+            }
+
+            Some(
+                parts
+                    .headers
+                    .get(header::SEC_WEBSOCKET_KEY)
+                    .ok_or(WebSocketKeyHeaderMissing)?
+                    .clone(),
+            )
+        } else {
+            if parts.method != Method::CONNECT {
+                return Err(MethodNotConnect.into());
+            }
+
+            #[cfg(feature = "http2")]
+            if parts
+                .extensions
+                .get::<hyper::ext::Protocol>()
+                .map_or(true, |p| p.as_str() != "websocket")
+            {
+                return Err(InvalidProtocolPseudoheader.into());
+            }
+
+            None
+        };
+
+        if !header_eq(&parts.headers, header::SEC_WEBSOCKET_VERSION, "13") {
+            return Err(InvalidWebSocketVersionHeader.into());
+        }
+
+        let on_upgrade = parts
+            .extensions
+            .remove::<hyper::upgrade::OnUpgrade>()
+            .ok_or(ConnectionNotUpgradable)?;
+
+        let sec_websocket_protocol = parts.headers.get(header::SEC_WEBSOCKET_PROTOCOL).cloned();
+
+        Ok(Self {
+            config: Default::default(),
+            protocol: None,
+            sec_websocket_key,
+            on_upgrade,
+            sec_websocket_protocol,
+            on_failed_upgrade: DefaultOnFailedUpgrade,
+        })
+    }
+}
+
+// ===== Helpers =====
+
+fn header_eq(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
+    if let Some(header) = headers.get(&key) {
+        header.as_bytes().eq_ignore_ascii_case(value.as_bytes())
+    } else {
+        false
+    }
+}
+
+fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
+    let header = if let Some(header) = headers.get(&key) {
+        header
+    } else {
+        return false;
+    };
+
+    if let Ok(header) = std::str::from_utf8(header.as_bytes()) {
+        header.to_ascii_lowercase().contains(value)
+    } else {
+        false
+    }
+}
+
+fn sign(key: &[u8]) -> HeaderValue {
+    use base64::engine::Engine as _;
+
+    let mut sha1 = Sha1::default();
+    sha1.update(key);
+    sha1.update(&b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"[..]);
+    let b64 = ts::Bytes::from(base64::engine::general_purpose::STANDARD.encode(sha1.finalize()));
+    HeaderValue::from_maybe_shared(b64).expect("base64 is a valid value")
+}
+
+// ===== Rejection types =====
+
+pub mod rejection {
+    //! WebSocket specific rejections.
+
+    use axum_core::{
+        __composite_rejection as composite_rejection, __define_rejection as define_rejection,
+    };
+    use hyper::http;
+
+    define_rejection! {
+        #[status = METHOD_NOT_ALLOWED]
+        #[body = "Request method must be `GET`"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct MethodNotGet;
+    }
+
+    define_rejection! {
+        #[status = METHOD_NOT_ALLOWED]
+        #[body = "Request method must be `CONNECT`"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct MethodNotConnect;
+    }
+
+    define_rejection! {
+        #[status = BAD_REQUEST]
+        #[body = "Connection header did not include 'upgrade'"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct InvalidConnectionHeader;
+    }
+
+    define_rejection! {
+        #[status = BAD_REQUEST]
+        #[body = "`Upgrade` header did not include 'websocket'"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct InvalidUpgradeHeader;
+    }
+
+    define_rejection! {
+        #[status = BAD_REQUEST]
+        #[body = "`:protocol` pseudo-header did not include 'websocket'"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct InvalidProtocolPseudoheader;
+    }
+
+    define_rejection! {
+        #[status = BAD_REQUEST]
+        #[body = "`Sec-WebSocket-Version` header did not include '13'"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct InvalidWebSocketVersionHeader;
+    }
+
+    define_rejection! {
+        #[status = BAD_REQUEST]
+        #[body = "`Sec-WebSocket-Key` header missing"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct WebSocketKeyHeaderMissing;
+    }
+
+    define_rejection! {
+        #[status = UPGRADE_REQUIRED]
+        #[body = "WebSocket request couldn't be upgraded since no upgrade state was present"]
+        /// Rejection type for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        pub struct ConnectionNotUpgradable;
+    }
+
+    composite_rejection! {
+        /// Rejection used for [`WebSocketUpgrade`](super::WebSocketUpgrade).
+        ///
+        /// Contains one variant for each way the
+        /// [`WebSocketUpgrade`](super::WebSocketUpgrade) extractor can fail.
+        pub enum WebSocketUpgradeRejection {
+            MethodNotGet,
+            MethodNotConnect,
+            InvalidConnectionHeader,
+            InvalidUpgradeHeader,
+            InvalidProtocolPseudoheader,
+            InvalidWebSocketVersionHeader,
+            WebSocketKeyHeaderMissing,
+            ConnectionNotUpgradable,
+        }
+    }
+}
+
+// ===== Close codes =====
+
+pub mod close_code {
+    //! Constants for [`CloseCode`]s.
+    //!
+    //! [`CloseCode`]: super::CloseCode
+
+    /// Indicates a normal closure, meaning that the purpose for which the
+    /// connection was established has been fulfilled.
+    pub const NORMAL: u16 = 1000;
+    /// Indicates that an endpoint is "going away", such as a server going down
+    /// or a browser having navigated away from a page.
+    pub const AWAY: u16 = 1001;
+    /// Indicates that an endpoint is terminating the connection due to a
+    /// protocol error.
+    pub const PROTOCOL: u16 = 1002;
+    /// Indicates that an endpoint is terminating the connection because it has
+    /// received a type of data that it cannot accept.
+    pub const UNSUPPORTED: u16 = 1003;
+    /// Indicates that no status code was included in a closing frame.
+    pub const STATUS: u16 = 1005;
+    /// Indicates an abnormal closure.
+    pub const ABNORMAL: u16 = 1006;
+    /// Indicates that an endpoint is terminating the connection because it has
+    /// received data within a message that was not consistent with the type of
+    /// the message.
+    pub const INVALID: u16 = 1007;
+    /// Indicates that an endpoint is terminating the connection because it has
+    /// received a message that violates its policy.
+    pub const POLICY: u16 = 1008;
+    /// Indicates that an endpoint is terminating the connection because it has
+    /// received a message that is too big for it to process.
+    pub const SIZE: u16 = 1009;
+    /// Indicates that an endpoint (client) is terminating the connection
+    /// because the server did not respond to extension negotiation
+    /// correctly.
+    pub const EXTENSION: u16 = 1010;
+    /// Indicates that a server is terminating the connection because it
+    /// encountered an unexpected condition that prevented it from fulfilling
+    /// the request.
+    pub const ERROR: u16 = 1011;
+    /// Indicates that the server is restarting.
+    pub const RESTART: u16 = 1012;
+    /// Indicates that the server is overloaded and the client should either
+    /// connect to a different IP (when multiple targets exist), or reconnect to
+    /// the same IP when a user has performed an action.
+    pub const AGAIN: u16 = 1013;
+}

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -32,174 +32,20 @@
 //! # let _: Router = app;
 //! ```
 
-use std::{
-    borrow::Cow,
-    future::Future,
-    io,
-    pin::Pin,
-    task::{Poll, ready},
-};
+use std::{borrow::Cow, future::Future};
 
 use axum_core::{body::Body, extract::FromRequestParts, response::Response};
+use compio_ws::tungstenite::{self as ts, protocol::WebSocketConfig};
+use cyper_core::CompioStream;
 use hyper::{
     Method, StatusCode, Version,
     header::{self, HeaderMap, HeaderName, HeaderValue},
     http::request::Parts,
-    rt::{Read as _, Write as _},
-    upgrade::Upgraded,
 };
 use send_wrapper::SendWrapper;
 use sha1::{Digest, Sha1};
-use tungstenite::{self as ts, protocol::WebSocketConfig};
 
 use self::rejection::*;
-
-// ===== UpgradedIo =====
-
-const DEFAULT_BUF_SIZE: usize = 8 * 1024;
-const MAX_BUF_SIZE: usize = 64 * 1024 * 1024;
-
-/// Adapter that bridges `hyper::upgrade::Upgraded` (poll-based hyper::rt IO)
-/// to sync `Read + Write` with internal buffers, suitable for tungstenite.
-struct UpgradedIo {
-    upgraded: Upgraded,
-    read_buf: Vec<u8>,
-    read_pos: usize,
-    write_buf: Vec<u8>,
-}
-
-impl UpgradedIo {
-    fn new(upgraded: Upgraded) -> Self {
-        Self {
-            upgraded,
-            read_buf: Vec::with_capacity(DEFAULT_BUF_SIZE),
-            read_pos: 0,
-            write_buf: Vec::with_capacity(DEFAULT_BUF_SIZE),
-        }
-    }
-
-    fn available_read(&self) -> &[u8] {
-        &self.read_buf[self.read_pos..]
-    }
-
-    fn consume_read(&mut self, amt: usize) {
-        self.read_pos += amt;
-        if self.read_pos == self.read_buf.len() {
-            self.read_buf.clear();
-            self.read_pos = 0;
-            // Shrink if oversized
-            if self.read_buf.capacity() > DEFAULT_BUF_SIZE * 4 {
-                self.read_buf.shrink_to(DEFAULT_BUF_SIZE);
-            }
-        }
-    }
-
-    /// Fill read buffer by polling the upgraded connection.
-    async fn fill_read_buf(&mut self) -> io::Result<usize> {
-        // Compact: move unconsumed data to front
-        if self.read_pos > 0 {
-            self.read_buf.drain(..self.read_pos);
-            self.read_pos = 0;
-        }
-
-        // Ensure space
-        let current_len = self.read_buf.len();
-        if current_len >= MAX_BUF_SIZE {
-            return Err(io::Error::new(
-                io::ErrorKind::OutOfMemory,
-                "read buffer size limit exceeded",
-            ));
-        }
-        let needed = DEFAULT_BUF_SIZE;
-        self.read_buf.reserve(needed);
-
-        let read = futures_util::future::poll_fn(|cx| {
-            // SAFETY: spare capacity is valid for writing
-            let spare = self.read_buf.spare_capacity_mut();
-            let mut buf = hyper::rt::ReadBuf::uninit(spare);
-            let filled_before = buf.filled().len();
-            ready!(Pin::new(&mut self.upgraded).poll_read(cx, buf.unfilled()))?;
-            let filled_after = buf.filled().len();
-            let n = filled_after - filled_before;
-            Poll::Ready(Ok::<_, io::Error>(n))
-        })
-        .await?;
-
-        // SAFETY: poll_read initialized `read` more bytes
-        unsafe {
-            self.read_buf.set_len(current_len + read);
-        }
-        Ok(read)
-    }
-
-    /// Flush write buffer to the upgraded connection.
-    async fn flush_write_buf(&mut self) -> io::Result<usize> {
-        let mut written_total = 0;
-        while written_total < self.write_buf.len() {
-            let written = futures_util::future::poll_fn(|cx| {
-                let buf = &self.write_buf[written_total..];
-                Pin::new(&mut self.upgraded).poll_write(cx, buf)
-            })
-            .await?;
-            if written == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "write returned 0 bytes",
-                ));
-            }
-            written_total += written;
-        }
-        self.write_buf.clear();
-        if self.write_buf.capacity() > DEFAULT_BUF_SIZE * 4 {
-            self.write_buf.shrink_to(DEFAULT_BUF_SIZE);
-        }
-
-        // Also flush the underlying stream
-        futures_util::future::poll_fn(|cx| Pin::new(&mut self.upgraded).poll_flush(cx)).await?;
-
-        Ok(written_total)
-    }
-}
-
-impl io::Read for UpgradedIo {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let available = self.available_read();
-        if available.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "need to fill read buffer",
-            ));
-        }
-        let to_read = available.len().min(buf.len());
-        buf[..to_read].copy_from_slice(&available[..to_read]);
-        self.consume_read(to_read);
-        Ok(to_read)
-    }
-}
-
-impl io::Write for UpgradedIo {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if self.write_buf.len() + buf.len() > MAX_BUF_SIZE {
-            let space = MAX_BUF_SIZE - self.write_buf.len();
-            if space == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "write buffer full, need to flush",
-                ));
-            }
-            self.write_buf.extend_from_slice(&buf[..space]);
-            return Ok(space);
-        }
-        self.write_buf.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        // Intentionally no-op for tungstenite compatibility.
-        // Actual flushing happens via flush_write_buf().
-        Ok(())
-    }
-}
 
 // ===== Message types =====
 
@@ -479,15 +325,14 @@ impl From<Message> for Vec<u8> {
 /// A WebSocket stream.
 ///
 /// Use [`recv`](Self::recv) and [`send`](Self::send) to communicate.
-#[derive(Debug)]
 pub struct WebSocket {
-    inner: ts::WebSocket<UpgradedIo>,
+    inner: compio_ws::WebSocketStream<CompioStream<hyper::upgrade::Upgraded>>,
     protocol: Option<HeaderValue>,
 }
 
-impl std::fmt::Debug for UpgradedIo {
+impl std::fmt::Debug for WebSocket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UpgradedIo").finish_non_exhaustive()
+        f.debug_struct("WebSocket").finish_non_exhaustive()
     }
 }
 
@@ -497,48 +342,25 @@ impl WebSocket {
     /// Returns `None` if the stream has closed.
     pub async fn recv(&mut self) -> Option<Result<Message, axum_core::Error>> {
         loop {
-            match self.inner.read() {
+            match self.inner.read().await {
                 Ok(msg) => {
-                    // Flush any buffered writes (e.g. automatic pong replies)
-                    let _ = self.flush().await;
                     if let Some(msg) = Message::from_tungstenite(msg) {
                         return Some(Ok(msg));
                     }
                 }
-                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                    // Need more data
-                    match self.inner.get_mut().fill_read_buf().await {
-                        Ok(0) => return None, // EOF
-                        Ok(_) => continue,
-                        Err(e) => return Some(Err(axum_core::Error::new(e))),
-                    }
-                }
                 Err(ts::Error::ConnectionClosed) => return None,
                 Err(ts::Error::AlreadyClosed) => return None,
-                Err(e) => {
-                    let _ = self.flush().await;
-                    return Some(Err(axum_core::Error::new(e)));
-                }
+                Err(e) => return Some(Err(axum_core::Error::new(e))),
             }
         }
     }
 
     /// Send a message.
     pub async fn send(&mut self, msg: Message) -> Result<(), axum_core::Error> {
-        loop {
-            match self.inner.send(msg.clone().into_tungstenite()) {
-                Ok(()) => break,
-                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                    self.inner
-                        .get_mut()
-                        .flush_write_buf()
-                        .await
-                        .map_err(axum_core::Error::new)?;
-                }
-                Err(e) => return Err(axum_core::Error::new(e)),
-            }
-        }
-        self.flush().await
+        self.inner
+            .send(msg.into_tungstenite())
+            .await
+            .map_err(axum_core::Error::new)
     }
 
     /// Close the WebSocket connection.
@@ -547,49 +369,15 @@ impl WebSocket {
             code: ts::protocol::frame::coding::CloseCode::from(f.code),
             reason: f.reason.into_tungstenite(),
         });
-        loop {
-            match self.inner.close(ts_frame.clone()) {
-                Ok(()) => break,
-                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                    let io = self.inner.get_mut();
-                    let flushed = io.flush_write_buf().await.map_err(axum_core::Error::new)?;
-                    if flushed == 0 {
-                        io.fill_read_buf().await.map_err(axum_core::Error::new)?;
-                    }
-                }
-                Err(ts::Error::ConnectionClosed) => break,
-                Err(e) => return Err(axum_core::Error::new(e)),
-            }
-        }
-        self.flush().await
+        self.inner
+            .close(ts_frame)
+            .await
+            .map_err(axum_core::Error::new)
     }
 
     /// Return the selected WebSocket subprotocol, if one has been chosen.
     pub fn protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
-    }
-
-    async fn flush(&mut self) -> Result<(), axum_core::Error> {
-        loop {
-            match self.inner.flush() {
-                Ok(()) => break,
-                Err(ts::Error::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                    self.inner
-                        .get_mut()
-                        .flush_write_buf()
-                        .await
-                        .map_err(axum_core::Error::new)?;
-                }
-                Err(ts::Error::ConnectionClosed) => break,
-                Err(e) => return Err(axum_core::Error::new(e)),
-            }
-        }
-        self.inner
-            .get_mut()
-            .flush_write_buf()
-            .await
-            .map_err(axum_core::Error::new)?;
-        Ok(())
     }
 }
 
@@ -776,8 +564,13 @@ impl<F> WebSocketUpgrade<F> {
                 }
             };
 
-            let io = UpgradedIo::new(upgraded);
-            let ws = ts::WebSocket::from_raw_socket(io, ts::protocol::Role::Server, Some(config));
+            let stream = CompioStream::new(upgraded);
+            let ws = compio_ws::WebSocketStream::from_raw_socket(
+                stream,
+                ts::protocol::Role::Server,
+                config,
+            )
+            .await;
             let socket = WebSocket {
                 inner: ws,
                 protocol,

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -32,10 +32,10 @@
 //! # let _: Router = app;
 //! ```
 
-use std::{borrow::Cow, future::Future};
+use std::{borrow::Cow, collections::BTreeSet, future::Future};
 
 use axum_core::{body::Body, extract::FromRequestParts, response::Response};
-use compio_ws::tungstenite::{self as ts, protocol::WebSocketConfig};
+use compio::ws::tungstenite::{self as ts, protocol::WebSocketConfig};
 use cyper_core::CompioStream;
 use hyper::{
     Method, StatusCode, Version,
@@ -326,7 +326,7 @@ impl From<Message> for Vec<u8> {
 ///
 /// Use [`recv`](Self::recv) and [`send`](Self::send) to communicate.
 pub struct WebSocket {
-    inner: compio_ws::WebSocketStream<CompioStream<hyper::upgrade::Upgraded>>,
+    inner: compio::ws::WebSocketStream<CompioStream<hyper::upgrade::Upgraded>>,
     protocol: Option<HeaderValue>,
 }
 
@@ -419,7 +419,6 @@ impl OnFailedUpgrade for DefaultOnFailedUpgrade {
 /// For HTTP/1.1 requests, this extractor requires the request method to be
 /// `GET`; in later versions, `CONNECT` is used instead. To support both, it
 /// should be used with [`any`](axum::routing::any).
-#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 #[must_use]
 pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     config: WebSocketConfig,
@@ -427,7 +426,7 @@ pub struct WebSocketUpgrade<F = DefaultOnFailedUpgrade> {
     sec_websocket_key: Option<HeaderValue>,
     on_upgrade: hyper::upgrade::OnUpgrade,
     on_failed_upgrade: F,
-    sec_websocket_protocol: Option<HeaderValue>,
+    sec_websocket_protocol: BTreeSet<HeaderValue>,
 }
 
 impl<F> std::fmt::Debug for WebSocketUpgrade<F> {
@@ -499,30 +498,38 @@ impl<F> WebSocketUpgrade<F> {
         I: IntoIterator,
         I::Item: Into<Cow<'static, str>>,
     {
-        if let Some(req_protocols) = self
-            .sec_websocket_protocol
-            .as_ref()
-            .and_then(|p| p.to_str().ok())
-        {
-            self.protocol = protocols
-                .into_iter()
-                .map(Into::into)
-                .find(|protocol| {
-                    req_protocols
-                        .split(',')
-                        .any(|req_protocol| req_protocol.trim() == protocol.as_ref())
-                })
-                .map(|protocol| match protocol {
-                    Cow::Owned(s) => HeaderValue::from_str(&s).unwrap(),
-                    Cow::Borrowed(s) => HeaderValue::from_static(s),
-                });
-        }
+        self.protocol = protocols
+            .into_iter()
+            .map(Into::into)
+            .find(|proto| {
+                let Ok(proto) = HeaderValue::from_str(proto) else {
+                    return false;
+                };
+                self.sec_websocket_protocol.contains(&proto)
+            })
+            .map(|protocol| match protocol {
+                Cow::Owned(s) => HeaderValue::from_str(&s).unwrap(),
+                Cow::Borrowed(s) => HeaderValue::from_static(s),
+            });
 
         self
     }
 
-    /// Return the selected protocol after calling
-    /// [`protocols`](Self::protocols).
+    /// Return the WebSocket subprotocols requested by the client.
+    pub fn requested_protocols(&self) -> impl Iterator<Item = &HeaderValue> {
+        self.sec_websocket_protocol.iter()
+    }
+
+    /// Set the chosen WebSocket subprotocol.
+    ///
+    /// Another method, [`protocols()`](Self::protocols), also sets the chosen
+    /// WebSocket subprotocol. If both methods are called, only the latter call
+    /// takes effect.
+    pub fn set_selected_protocol(&mut self, protocol: HeaderValue) {
+        self.protocol = Some(protocol);
+    }
+
+    /// Return the selected WebSocket subprotocol, if one has been chosen.
     pub fn selected_protocol(&self) -> Option<&HeaderValue> {
         self.protocol.as_ref()
     }
@@ -565,7 +572,7 @@ impl<F> WebSocketUpgrade<F> {
             };
 
             let stream = CompioStream::new(upgraded);
-            let ws = compio_ws::WebSocketStream::from_raw_socket(
+            let ws = compio::ws::WebSocketStream::from_raw_socket(
                 stream,
                 ts::protocol::Role::Server,
                 config,
@@ -664,7 +671,16 @@ where
             .remove::<hyper::upgrade::OnUpgrade>()
             .ok_or(ConnectionNotUpgradable)?;
 
-        let sec_websocket_protocol = parts.headers.get(header::SEC_WEBSOCKET_PROTOCOL).cloned();
+        let sec_websocket_protocol = parts
+            .headers
+            .get_all(header::SEC_WEBSOCKET_PROTOCOL)
+            .iter()
+            .flat_map(|val| val.as_bytes().split(|&b| b == b','))
+            .map(|proto| {
+                HeaderValue::from_bytes(proto.trim_ascii())
+                    .expect("substring of HeaderValue is valid HeaderValue")
+            })
+            .collect();
 
         Ok(Self {
             config: Default::default(),

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -47,278 +47,10 @@ use sha1::{Digest, Sha1};
 
 use self::rejection::*;
 
-// ===== Message types =====
-
-/// UTF-8 wrapper for [ts::Bytes].
-///
-/// An [`Utf8Bytes`] is always guaranteed to contain valid UTF-8.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct Utf8Bytes(ts::Utf8Bytes);
-
-impl Utf8Bytes {
-    /// Creates from a static str.
-    #[inline]
-    #[must_use]
-    pub const fn from_static(str: &'static str) -> Self {
-        Self(ts::Utf8Bytes::from_static(str))
-    }
-
-    /// Returns as a string slice.
-    #[inline]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    fn into_tungstenite(self) -> ts::Utf8Bytes {
-        self.0
-    }
-}
-
-impl std::ops::Deref for Utf8Bytes {
-    type Target = str;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_str()
-    }
-}
-
-impl std::fmt::Display for Utf8Bytes {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl TryFrom<ts::Bytes> for Utf8Bytes {
-    type Error = std::str::Utf8Error;
-
-    #[inline]
-    fn try_from(bytes: ts::Bytes) -> Result<Self, Self::Error> {
-        Ok(Self(bytes.try_into()?))
-    }
-}
-
-impl TryFrom<Vec<u8>> for Utf8Bytes {
-    type Error = std::str::Utf8Error;
-
-    #[inline]
-    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
-        Ok(Self(v.try_into()?))
-    }
-}
-
-impl From<String> for Utf8Bytes {
-    #[inline]
-    fn from(s: String) -> Self {
-        Self(s.into())
-    }
-}
-
-impl From<&str> for Utf8Bytes {
-    #[inline]
-    fn from(s: &str) -> Self {
-        Self(s.into())
-    }
-}
-
-impl From<&String> for Utf8Bytes {
-    #[inline]
-    fn from(s: &String) -> Self {
-        Self(s.into())
-    }
-}
-
-impl From<Utf8Bytes> for ts::Bytes {
-    #[inline]
-    fn from(Utf8Bytes(bytes): Utf8Bytes) -> Self {
-        bytes.into()
-    }
-}
-
-impl<T> PartialEq<T> for Utf8Bytes
-where
-    for<'a> &'a str: PartialEq<T>,
-{
-    #[inline]
-    fn eq(&self, other: &T) -> bool {
-        self.as_str() == *other
-    }
-}
-
-/// Status code used to indicate why an endpoint is closing the WebSocket
-/// connection.
-pub type CloseCode = u16;
-
-/// A struct representing the close command.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct CloseFrame {
-    /// The reason as a code.
-    pub code: CloseCode,
-    /// The reason as text string.
-    pub reason: Utf8Bytes,
-}
-
-/// A WebSocket message.
-// This code comes from https://github.com/snapview/tungstenite-rs/blob/master/src/protocol/message.rs and is under following license:
-// Copyright (c) 2017 Alexey Galakhov
-// Copyright (c) 2016 Jason Housley
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Message {
-    /// A text WebSocket message
-    Text(Utf8Bytes),
-    /// A binary WebSocket message
-    Binary(ts::Bytes),
-    /// A ping message with the specified payload
-    ///
-    /// The payload here must have a length less than 125 bytes.
-    Ping(ts::Bytes),
-    /// A pong message with the specified payload
-    ///
-    /// The payload here must have a length less than 125 bytes.
-    Pong(ts::Bytes),
-    /// A close message with the optional close frame.
-    Close(Option<CloseFrame>),
-}
-
-impl Message {
-    fn into_tungstenite(self) -> ts::Message {
-        match self {
-            Self::Text(text) => ts::Message::Text(text.into_tungstenite()),
-            Self::Binary(binary) => ts::Message::Binary(binary),
-            Self::Ping(ping) => ts::Message::Ping(ping),
-            Self::Pong(pong) => ts::Message::Pong(pong),
-            Self::Close(Some(close)) => ts::Message::Close(Some(ts::protocol::CloseFrame {
-                code: ts::protocol::frame::coding::CloseCode::from(close.code),
-                reason: close.reason.into_tungstenite(),
-            })),
-            Self::Close(None) => ts::Message::Close(None),
-        }
-    }
-
-    fn from_tungstenite(message: ts::Message) -> Option<Self> {
-        match message {
-            ts::Message::Text(text) => Some(Self::Text(Utf8Bytes(text))),
-            ts::Message::Binary(binary) => Some(Self::Binary(binary)),
-            ts::Message::Ping(ping) => Some(Self::Ping(ping)),
-            ts::Message::Pong(pong) => Some(Self::Pong(pong)),
-            ts::Message::Close(Some(close)) => Some(Self::Close(Some(CloseFrame {
-                code: close.code.into(),
-                reason: Utf8Bytes(close.reason),
-            }))),
-            ts::Message::Close(None) => Some(Self::Close(None)),
-            // we can ignore `Frame` frames as recommended by the tungstenite maintainers
-            // https://github.com/snapview/tungstenite-rs/issues/268
-            ts::Message::Frame(_) => None,
-        }
-    }
-
-    /// Consume the WebSocket and return it as binary data.
-    pub fn into_data(self) -> ts::Bytes {
-        match self {
-            Self::Text(string) => ts::Bytes::from(string),
-            Self::Binary(data) | Self::Ping(data) | Self::Pong(data) => data,
-            Self::Close(None) => ts::Bytes::new(),
-            Self::Close(Some(frame)) => ts::Bytes::from(frame.reason),
-        }
-    }
-
-    /// Attempt to consume the WebSocket message and convert it to a
-    /// [`Utf8Bytes`].
-    pub fn into_text(self) -> Result<Utf8Bytes, axum_core::Error> {
-        match self {
-            Self::Text(string) => Ok(string),
-            Self::Binary(data) | Self::Ping(data) | Self::Pong(data) => {
-                Ok(Utf8Bytes::try_from(data).map_err(axum_core::Error::new)?)
-            }
-            Self::Close(None) => Ok(Utf8Bytes::default()),
-            Self::Close(Some(frame)) => Ok(frame.reason),
-        }
-    }
-
-    /// Attempt to get a &str from the WebSocket message,
-    /// this will try to convert binary data to utf8.
-    pub fn to_text(&self) -> Result<&str, axum_core::Error> {
-        match *self {
-            Self::Text(ref string) => Ok(string.as_str()),
-            Self::Binary(ref data) | Self::Ping(ref data) | Self::Pong(ref data) => {
-                Ok(std::str::from_utf8(data).map_err(axum_core::Error::new)?)
-            }
-            Self::Close(None) => Ok(""),
-            Self::Close(Some(ref frame)) => Ok(&frame.reason),
-        }
-    }
-
-    /// Create a new text WebSocket message from a stringable.
-    pub fn text<S>(string: S) -> Message
-    where
-        S: Into<Utf8Bytes>,
-    {
-        Message::Text(string.into())
-    }
-
-    /// Create a new binary WebSocket message by converting to `Bytes`.
-    pub fn binary<B>(bin: B) -> Message
-    where
-        B: Into<ts::Bytes>,
-    {
-        Message::Binary(bin.into())
-    }
-}
-
-impl From<String> for Message {
-    fn from(string: String) -> Self {
-        Message::Text(string.into())
-    }
-}
-
-impl<'s> From<&'s str> for Message {
-    fn from(string: &'s str) -> Self {
-        Message::Text(string.into())
-    }
-}
-
-impl<'b> From<&'b [u8]> for Message {
-    fn from(data: &'b [u8]) -> Self {
-        Message::Binary(ts::Bytes::copy_from_slice(data))
-    }
-}
-
-impl From<ts::Bytes> for Message {
-    fn from(data: ts::Bytes) -> Self {
-        Message::Binary(data)
-    }
-}
-
-impl From<Vec<u8>> for Message {
-    fn from(data: Vec<u8>) -> Self {
-        Message::Binary(data.into())
-    }
-}
-
-impl From<Message> for Vec<u8> {
-    fn from(msg: Message) -> Self {
-        msg.into_data().to_vec()
-    }
-}
+// Re-export tungstenite types for convenience.
+pub use ts::protocol::frame::coding::CloseCode;
+pub use ts::protocol::CloseFrame;
+pub use ts::{Bytes, Message, Utf8Bytes};
 
 // ===== WebSocket =====
 
@@ -344,7 +76,9 @@ impl WebSocket {
         loop {
             match self.inner.read().await {
                 Ok(msg) => {
-                    if let Some(msg) = Message::from_tungstenite(msg) {
+                    // Ignore `Frame` frames as recommended by the tungstenite maintainers
+                    // https://github.com/snapview/tungstenite-rs/issues/268
+                    if !matches!(msg, Message::Frame(_)) {
                         return Some(Ok(msg));
                     }
                 }
@@ -357,20 +91,13 @@ impl WebSocket {
 
     /// Send a message.
     pub async fn send(&mut self, msg: Message) -> Result<(), axum_core::Error> {
-        self.inner
-            .send(msg.into_tungstenite())
-            .await
-            .map_err(axum_core::Error::new)
+        self.inner.send(msg).await.map_err(axum_core::Error::new)
     }
 
     /// Close the WebSocket connection.
     pub async fn close(mut self, close_frame: Option<CloseFrame>) -> Result<(), axum_core::Error> {
-        let ts_frame = close_frame.map(|f| ts::protocol::CloseFrame {
-            code: ts::protocol::frame::coding::CloseCode::from(f.code),
-            reason: f.reason.into_tungstenite(),
-        });
         self.inner
-            .close(ts_frame)
+            .close(close_frame)
             .await
             .map_err(axum_core::Error::new)
     }
@@ -551,6 +278,7 @@ impl<F> WebSocketUpgrade<F> {
 
     /// Finalize upgrading the connection and call the provided callback with
     /// the stream.
+    #[must_use = "to set up the WebSocket connection, this response must be returned"]
     pub fn on_upgrade<C, Fut>(self, callback: C) -> Response
     where
         C: FnOnce(WebSocket) -> Fut + 'static,
@@ -809,53 +537,4 @@ pub mod rejection {
             ConnectionNotUpgradable,
         }
     }
-}
-
-// ===== Close codes =====
-
-pub mod close_code {
-    //! Constants for [`CloseCode`]s.
-    //!
-    //! [`CloseCode`]: super::CloseCode
-
-    /// Indicates a normal closure, meaning that the purpose for which the
-    /// connection was established has been fulfilled.
-    pub const NORMAL: u16 = 1000;
-    /// Indicates that an endpoint is "going away", such as a server going down
-    /// or a browser having navigated away from a page.
-    pub const AWAY: u16 = 1001;
-    /// Indicates that an endpoint is terminating the connection due to a
-    /// protocol error.
-    pub const PROTOCOL: u16 = 1002;
-    /// Indicates that an endpoint is terminating the connection because it has
-    /// received a type of data that it cannot accept.
-    pub const UNSUPPORTED: u16 = 1003;
-    /// Indicates that no status code was included in a closing frame.
-    pub const STATUS: u16 = 1005;
-    /// Indicates an abnormal closure.
-    pub const ABNORMAL: u16 = 1006;
-    /// Indicates that an endpoint is terminating the connection because it has
-    /// received data within a message that was not consistent with the type of
-    /// the message.
-    pub const INVALID: u16 = 1007;
-    /// Indicates that an endpoint is terminating the connection because it has
-    /// received a message that violates its policy.
-    pub const POLICY: u16 = 1008;
-    /// Indicates that an endpoint is terminating the connection because it has
-    /// received a message that is too big for it to process.
-    pub const SIZE: u16 = 1009;
-    /// Indicates that an endpoint (client) is terminating the connection
-    /// because the server did not respond to extension negotiation
-    /// correctly.
-    pub const EXTENSION: u16 = 1010;
-    /// Indicates that a server is terminating the connection because it
-    /// encountered an unexpected condition that prevented it from fulfilling
-    /// the request.
-    pub const ERROR: u16 = 1011;
-    /// Indicates that the server is restarting.
-    pub const RESTART: u16 = 1012;
-    /// Indicates that the server is overloaded and the client should either
-    /// connect to a different IP (when multiple targets exist), or reconnect to
-    /// the same IP when a user has performed an action.
-    pub const AGAIN: u16 = 1013;
 }

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -44,13 +44,11 @@ use hyper::{
 };
 use send_wrapper::SendWrapper;
 use sha1::{Digest, Sha1};
-
-use self::rejection::*;
-
 // Re-export tungstenite types for convenience.
 pub use ts::protocol::frame::coding::CloseCode;
-pub use ts::protocol::CloseFrame;
-pub use ts::{Bytes, Message, Utf8Bytes};
+pub use ts::{Bytes, Message, Utf8Bytes, protocol::CloseFrame};
+
+use self::rejection::*;
 
 // ===== WebSocket =====
 
@@ -382,7 +380,7 @@ where
             if parts
                 .extensions
                 .get::<hyper::ext::Protocol>()
-                .map_or(true, |p| p.as_str() != "websocket")
+                .is_none_or(|p| p.as_str() != "websocket")
             {
                 return Err(InvalidProtocolPseudoheader.into());
             }

--- a/cyper-axum/tests/ws.rs
+++ b/cyper-axum/tests/ws.rs
@@ -216,7 +216,7 @@ async fn server_close() {
             if let Some(Ok(_msg)) = socket.recv().await {
                 socket
                     .close(Some(cyper_axum::ws::CloseFrame {
-                        code: cyper_axum::ws::close_code::NORMAL,
+                        code: cyper_axum::ws::CloseCode::Normal,
                         reason: "bye".into(),
                     }))
                     .await

--- a/cyper-axum/tests/ws.rs
+++ b/cyper-axum/tests/ws.rs
@@ -1,8 +1,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
 
 use axum::{Router, response::Response, routing::any};
-use compio::net::TcpListener;
-use compio::ws::tungstenite::Message as TsMessage;
+use compio::{net::TcpListener, ws::tungstenite::Message as TsMessage};
 use cyper_axum::ws::{Message, WebSocket, WebSocketUpgrade};
 use futures_channel::oneshot;
 
@@ -49,11 +48,10 @@ async fn echo_handler(ws: WebSocketUpgrade) -> Response {
 async fn echo_socket(mut socket: WebSocket) {
     while let Some(Ok(msg)) = socket.recv().await {
         match msg {
-            Message::Text(_) | Message::Binary(_) => {
-                if socket.send(msg).await.is_err() {
-                    break;
-                }
+            Message::Text(_) | Message::Binary(_) if socket.send(msg.clone()).await.is_err() => {
+                break;
             }
+
             Message::Close(_) => break,
             _ => {}
         }
@@ -127,9 +125,9 @@ async fn ping_pong() {
     let (addr, _shutdown) = spawn_server(app).await;
     let mut ws = connect(addr).await;
 
-    ws.send(TsMessage::Ping(compio::ws::tungstenite::Bytes::from_static(
-        b"ping",
-    )))
+    ws.send(TsMessage::Ping(
+        compio::ws::tungstenite::Bytes::from_static(b"ping"),
+    ))
     .await
     .unwrap();
     let msg = ws.read().await.unwrap();

--- a/cyper-axum/tests/ws.rs
+++ b/cyper-axum/tests/ws.rs
@@ -1,37 +1,17 @@
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 
-use axum::{
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    response::Response,
-    routing::any,
-    Router,
-};
+use axum::{Router, response::Response, routing::any};
 use compio::net::TcpListener;
+use compio_ws::tungstenite::Message as TsMessage;
+use cyper_axum::ws::{Message, WebSocket, WebSocketUpgrade};
 use futures_channel::oneshot;
 
-async fn ws_handler(ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(handle_socket)
-}
+// ===== Helpers =====
 
-async fn handle_socket(mut socket: WebSocket) {
-    while let Some(Ok(msg)) = socket.recv().await {
-        match msg {
-            Message::Text(text) => {
-                if socket.send(Message::Text(text)).await.is_err() {
-                    break;
-                }
-            }
-            Message::Close(_) => break,
-            _ => {}
-        }
-    }
-}
-
-#[compio::test]
-async fn websocket_echo() {
+/// Spawn a cyper-axum server with the given router, return its address and a
+/// shutdown handle (drop to stop).
+async fn spawn_server(app: Router) -> (SocketAddr, oneshot::Sender<()>) {
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-
-    let app = Router::new().route("/ws", any(ws_handler));
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
         .await
@@ -48,23 +28,248 @@ async fn websocket_echo() {
     })
     .detach();
 
-    // Connect with compio-ws client
+    (addr, shutdown_tx)
+}
+
+/// Connect a compio-ws client to the given address at `/ws`.
+async fn connect(addr: SocketAddr) -> compio_ws::WebSocketStream<compio::net::TcpStream> {
     let stream = compio::net::TcpStream::connect(addr).await.unwrap();
-    let (mut ws, _resp) =
-        compio_ws::client_async(format!("ws://{addr}/ws"), stream)
-            .await
-            .expect("WebSocket handshake failed");
-
-    // Send a message
-    ws.send(compio_ws::tungstenite::Message::Text("hello".into()))
+    let (ws, _resp) = compio_ws::client_async(format!("ws://{addr}/ws"), stream)
         .await
-        .expect("failed to send message");
+        .expect("WebSocket handshake failed");
+    ws
+}
 
-    // Receive the echo
-    let msg = ws.read().await.expect("failed to read message");
-    assert_eq!(msg, compio_ws::tungstenite::Message::Text("hello".into()));
+// ===== Echo handler (echoes text and binary) =====
 
-    // Clean up
+async fn echo_handler(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(echo_socket)
+}
+
+async fn echo_socket(mut socket: WebSocket) {
+    while let Some(Ok(msg)) = socket.recv().await {
+        match msg {
+            Message::Text(_) | Message::Binary(_) => {
+                if socket.send(msg).await.is_err() {
+                    break;
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+}
+
+// ===== Tests =====
+
+#[compio::test]
+async fn echo_text() {
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    ws.send(TsMessage::Text("hello".into())).await.unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Text("hello".into()));
+
     ws.close(None).await.ok();
-    drop(shutdown_tx);
+}
+
+#[compio::test]
+async fn echo_binary() {
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    let data = compio_ws::tungstenite::Bytes::from_static(b"\x00\x01\x02\x03");
+    ws.send(TsMessage::Binary(data.clone())).await.unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Binary(data));
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn multiple_messages() {
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    for i in 0..10 {
+        let text = format!("message {i}");
+        ws.send(TsMessage::Text(text.clone().into())).await.unwrap();
+        let msg = ws.read().await.unwrap();
+        assert_eq!(msg, TsMessage::Text(text.into()));
+    }
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn large_message() {
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    // 256 KiB text message — exercises buffer growth in UpgradedIo
+    let big = "x".repeat(256 * 1024);
+    ws.send(TsMessage::Text(big.clone().into())).await.unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Text(big.into()));
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn ping_pong() {
+    // tungstenite auto-replies to pings, so we send a ping and expect a pong
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    ws.send(TsMessage::Ping(compio_ws::tungstenite::Bytes::from_static(
+        b"ping",
+    )))
+    .await
+    .unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(
+        msg,
+        TsMessage::Pong(compio_ws::tungstenite::Bytes::from_static(b"ping"))
+    );
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn graceful_close() {
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    // Send a text, get echo, then close with a reason
+    ws.send(TsMessage::Text("before close".into()))
+        .await
+        .unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Text("before close".into()));
+
+    ws.close(Some(compio_ws::tungstenite::protocol::CloseFrame {
+        code: compio_ws::tungstenite::protocol::frame::coding::CloseCode::Normal,
+        reason: "done".into(),
+    }))
+    .await
+    .unwrap();
+}
+
+#[compio::test]
+async fn protocol_negotiation() {
+    async fn handler(ws: WebSocketUpgrade) -> Response {
+        let ws = ws.protocols(["graphql-ws", "echo"]);
+        assert_eq!(ws.selected_protocol().unwrap(), "echo");
+        ws.on_upgrade(|mut socket| async move {
+            assert_eq!(socket.protocol().unwrap(), "echo");
+            while let Some(Ok(msg)) = socket.recv().await {
+                match msg {
+                    Message::Text(_) | Message::Binary(_) => {
+                        if socket.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+        })
+    }
+
+    let app = Router::new().route("/ws", any(handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+
+    let stream = compio::net::TcpStream::connect(addr).await.unwrap();
+    let req = compio_ws::tungstenite::client::IntoClientRequest::into_client_request(format!(
+        "ws://{addr}/ws"
+    ))
+    .unwrap();
+    // Build request with subprotocol header
+    let mut req = req;
+    req.headers_mut()
+        .insert("Sec-WebSocket-Protocol", "echo, other".parse().unwrap());
+    let (mut ws, resp) = compio_ws::client_async(req, stream).await.unwrap();
+
+    assert_eq!(
+        resp.headers().get("Sec-WebSocket-Protocol").unwrap(),
+        "echo"
+    );
+
+    ws.send(TsMessage::Text("proto test".into())).await.unwrap();
+    let msg = ws.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Text("proto test".into()));
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn server_close() {
+    // Server sends close after first message
+    async fn handler(ws: WebSocketUpgrade) -> Response {
+        ws.on_upgrade(|mut socket| async move {
+            if let Some(Ok(_msg)) = socket.recv().await {
+                socket
+                    .close(Some(cyper_axum::ws::CloseFrame {
+                        code: cyper_axum::ws::close_code::NORMAL,
+                        reason: "bye".into(),
+                    }))
+                    .await
+                    .ok();
+            }
+        })
+    }
+
+    let app = Router::new().route("/ws", any(handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    ws.send(TsMessage::Text("trigger close".into()))
+        .await
+        .unwrap();
+
+    // Should receive the close frame
+    let msg = ws.read().await.unwrap();
+    match msg {
+        TsMessage::Close(Some(frame)) => {
+            assert_eq!(
+                frame.code,
+                compio_ws::tungstenite::protocol::frame::coding::CloseCode::Normal
+            );
+            assert_eq!(frame.reason.as_str(), "bye");
+        }
+        TsMessage::Close(None) => {} // also acceptable
+        other => panic!("expected Close, got {other:?}"),
+    }
+
+    ws.close(None).await.ok();
+}
+
+#[compio::test]
+async fn client_drop_does_not_panic_server() {
+    // Ensure the server doesn't panic when the client disconnects abruptly
+    let app = Router::new().route("/ws", any(echo_handler));
+    let (addr, _shutdown) = spawn_server(app).await;
+    let mut ws = connect(addr).await;
+
+    ws.send(TsMessage::Text("hello".into())).await.unwrap();
+    let _ = ws.read().await.unwrap();
+
+    // Drop without close — server should handle gracefully
+    drop(ws);
+
+    // Verify server is still alive by connecting again
+    let mut ws2 = connect(addr).await;
+    ws2.send(TsMessage::Text("still alive".into()))
+        .await
+        .unwrap();
+    let msg = ws2.read().await.unwrap();
+    assert_eq!(msg, TsMessage::Text("still alive".into()));
+
+    ws2.close(None).await.ok();
 }

--- a/cyper-axum/tests/ws.rs
+++ b/cyper-axum/tests/ws.rs
@@ -1,0 +1,70 @@
+use std::net::Ipv4Addr;
+
+use axum::{
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    response::Response,
+    routing::any,
+    Router,
+};
+use compio::net::TcpListener;
+use futures_channel::oneshot;
+
+async fn ws_handler(ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    while let Some(Ok(msg)) = socket.recv().await {
+        match msg {
+            Message::Text(text) => {
+                if socket.send(Message::Text(text)).await.is_err() {
+                    break;
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+}
+
+#[compio::test]
+async fn websocket_echo() {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let app = Router::new().route("/ws", any(ws_handler));
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    compio::runtime::spawn(async move {
+        cyper_axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown_rx.await.ok();
+            })
+            .await
+            .unwrap();
+    })
+    .detach();
+
+    // Connect with compio-ws client
+    let stream = compio::net::TcpStream::connect(addr).await.unwrap();
+    let (mut ws, _resp) =
+        compio_ws::client_async(format!("ws://{addr}/ws"), stream)
+            .await
+            .expect("WebSocket handshake failed");
+
+    // Send a message
+    ws.send(compio_ws::tungstenite::Message::Text("hello".into()))
+        .await
+        .expect("failed to send message");
+
+    // Receive the echo
+    let msg = ws.read().await.expect("failed to read message");
+    assert_eq!(msg, compio_ws::tungstenite::Message::Text("hello".into()));
+
+    // Clean up
+    ws.close(None).await.ok();
+    drop(shutdown_tx);
+}

--- a/cyper-axum/tests/ws.rs
+++ b/cyper-axum/tests/ws.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 use axum::{Router, response::Response, routing::any};
 use compio::net::TcpListener;
-use compio_ws::tungstenite::Message as TsMessage;
+use compio::ws::tungstenite::Message as TsMessage;
 use cyper_axum::ws::{Message, WebSocket, WebSocketUpgrade};
 use futures_channel::oneshot;
 
@@ -32,9 +32,9 @@ async fn spawn_server(app: Router) -> (SocketAddr, oneshot::Sender<()>) {
 }
 
 /// Connect a compio-ws client to the given address at `/ws`.
-async fn connect(addr: SocketAddr) -> compio_ws::WebSocketStream<compio::net::TcpStream> {
+async fn connect(addr: SocketAddr) -> compio::ws::WebSocketStream<compio::net::TcpStream> {
     let stream = compio::net::TcpStream::connect(addr).await.unwrap();
-    let (ws, _resp) = compio_ws::client_async(format!("ws://{addr}/ws"), stream)
+    let (ws, _resp) = compio::ws::client_async(format!("ws://{addr}/ws"), stream)
         .await
         .expect("WebSocket handshake failed");
     ws
@@ -81,7 +81,7 @@ async fn echo_binary() {
     let (addr, _shutdown) = spawn_server(app).await;
     let mut ws = connect(addr).await;
 
-    let data = compio_ws::tungstenite::Bytes::from_static(b"\x00\x01\x02\x03");
+    let data = compio::ws::tungstenite::Bytes::from_static(b"\x00\x01\x02\x03");
     ws.send(TsMessage::Binary(data.clone())).await.unwrap();
     let msg = ws.read().await.unwrap();
     assert_eq!(msg, TsMessage::Binary(data));
@@ -127,7 +127,7 @@ async fn ping_pong() {
     let (addr, _shutdown) = spawn_server(app).await;
     let mut ws = connect(addr).await;
 
-    ws.send(TsMessage::Ping(compio_ws::tungstenite::Bytes::from_static(
+    ws.send(TsMessage::Ping(compio::ws::tungstenite::Bytes::from_static(
         b"ping",
     )))
     .await
@@ -135,7 +135,7 @@ async fn ping_pong() {
     let msg = ws.read().await.unwrap();
     assert_eq!(
         msg,
-        TsMessage::Pong(compio_ws::tungstenite::Bytes::from_static(b"ping"))
+        TsMessage::Pong(compio::ws::tungstenite::Bytes::from_static(b"ping"))
     );
 
     ws.close(None).await.ok();
@@ -154,8 +154,8 @@ async fn graceful_close() {
     let msg = ws.read().await.unwrap();
     assert_eq!(msg, TsMessage::Text("before close".into()));
 
-    ws.close(Some(compio_ws::tungstenite::protocol::CloseFrame {
-        code: compio_ws::tungstenite::protocol::frame::coding::CloseCode::Normal,
+    ws.close(Some(compio::ws::tungstenite::protocol::CloseFrame {
+        code: compio::ws::tungstenite::protocol::frame::coding::CloseCode::Normal,
         reason: "done".into(),
     }))
     .await
@@ -186,7 +186,7 @@ async fn protocol_negotiation() {
     let (addr, _shutdown) = spawn_server(app).await;
 
     let stream = compio::net::TcpStream::connect(addr).await.unwrap();
-    let req = compio_ws::tungstenite::client::IntoClientRequest::into_client_request(format!(
+    let req = compio::ws::tungstenite::client::IntoClientRequest::into_client_request(format!(
         "ws://{addr}/ws"
     ))
     .unwrap();
@@ -194,7 +194,7 @@ async fn protocol_negotiation() {
     let mut req = req;
     req.headers_mut()
         .insert("Sec-WebSocket-Protocol", "echo, other".parse().unwrap());
-    let (mut ws, resp) = compio_ws::client_async(req, stream).await.unwrap();
+    let (mut ws, resp) = compio::ws::client_async(req, stream).await.unwrap();
 
     assert_eq!(
         resp.headers().get("Sec-WebSocket-Protocol").unwrap(),
@@ -239,7 +239,7 @@ async fn server_close() {
         TsMessage::Close(Some(frame)) => {
             assert_eq!(
                 frame.code,
-                compio_ws::tungstenite::protocol::frame::coding::CloseCode::Normal
+                compio::ws::tungstenite::protocol::frame::coding::CloseCode::Normal
             );
             assert_eq!(frame.reason.as_str(), "bye");
         }

--- a/cyper-core/src/stream.rs
+++ b/cyper-core/src/stream.rs
@@ -1,11 +1,15 @@
 use std::{
     io,
+    mem::MaybeUninit,
     ops::DerefMut,
     pin::Pin,
     task::{Context, Poll, ready},
 };
 
-use compio::io::{AsyncRead, AsyncWrite, compat::AsyncStream};
+use compio::{
+    buf::{BufResult, IoBuf, IoBufMut},
+    io::{AsyncRead, AsyncWrite, compat::AsyncStream},
+};
 use send_wrapper::SendWrapper;
 
 /// A stream wrapper for hyper.
@@ -61,5 +65,80 @@ impl<S: AsyncWrite + Unpin + 'static> hyper::rt::Write for HyperStream<S> {
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let stream = unsafe { self.map_unchecked_mut(|this| this.0.deref_mut()) };
         futures_util::AsyncWrite::poll_close(stream, cx)
+    }
+}
+
+/// A wrapper that bridges hyper's poll-based IO (`hyper::rt::Read + Write`)
+/// to compio's ownership-based async IO (`AsyncRead + AsyncWrite`).
+///
+/// This is the reverse of [`HyperStream`]: where `HyperStream` wraps a compio
+/// stream for use with hyper, `CompioStream` wraps a hyper stream for use with
+/// compio.
+pub struct CompioStream<S>(S);
+
+impl<S> CompioStream<S> {
+    /// Create a compio stream wrapper from a hyper-compatible stream.
+    pub fn new(s: S) -> Self {
+        Self(s)
+    }
+
+    /// Get a reference to the inner stream.
+    pub fn get_ref(&self) -> &S {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner stream.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.0
+    }
+
+    /// Consume the wrapper, returning the inner stream.
+    pub fn into_inner(self) -> S {
+        self.0
+    }
+}
+
+impl<S: std::fmt::Debug> std::fmt::Debug for CompioStream<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompioStream")
+            .field("inner", &self.0)
+            .finish()
+    }
+}
+
+impl<S: hyper::rt::Read + Unpin> AsyncRead for CompioStream<S> {
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
+        let result = futures_util::future::poll_fn(|cx| {
+            let uninit: &mut [MaybeUninit<u8>] = buf.as_uninit();
+            let mut read_buf = hyper::rt::ReadBuf::uninit(uninit);
+            ready!(Pin::new(&mut self.0).poll_read(cx, read_buf.unfilled()))?;
+            Poll::Ready(Ok::<_, io::Error>(read_buf.filled().len()))
+        })
+        .await;
+        match result {
+            Ok(n) => {
+                // SAFETY: poll_read initialized `n` bytes from the beginning.
+                unsafe { buf.set_len(n) };
+                BufResult(Ok(n), buf)
+            }
+            Err(e) => BufResult(Err(e), buf),
+        }
+    }
+}
+
+impl<S: hyper::rt::Write + Unpin> AsyncWrite for CompioStream<S> {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let result =
+            futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_write(cx, buf.as_init()))
+                .await;
+        BufResult(result, buf)
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_flush(cx)).await
+    }
+
+    async fn shutdown(&mut self) -> io::Result<()> {
+        futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_shutdown(cx)).await
     }
 }

--- a/cyper-core/src/stream.rs
+++ b/cyper-core/src/stream.rs
@@ -129,8 +129,7 @@ impl<S: hyper::rt::Read + Unpin> AsyncRead for CompioStream<S> {
 impl<S: hyper::rt::Write + Unpin> AsyncWrite for CompioStream<S> {
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
         let result =
-            std::future::poll_fn(|cx| Pin::new(&mut self.0).poll_write(cx, buf.as_init()))
-                .await;
+            std::future::poll_fn(|cx| Pin::new(&mut self.0).poll_write(cx, buf.as_init())).await;
         BufResult(result, buf)
     }
 

--- a/cyper-core/src/stream.rs
+++ b/cyper-core/src/stream.rs
@@ -108,7 +108,7 @@ impl<S: std::fmt::Debug> std::fmt::Debug for CompioStream<S> {
 
 impl<S: hyper::rt::Read + Unpin> AsyncRead for CompioStream<S> {
     async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
-        let result = futures_util::future::poll_fn(|cx| {
+        let result = std::future::poll_fn(|cx| {
             let uninit: &mut [MaybeUninit<u8>] = buf.as_uninit();
             let mut read_buf = hyper::rt::ReadBuf::uninit(uninit);
             ready!(Pin::new(&mut self.0).poll_read(cx, read_buf.unfilled()))?;
@@ -129,16 +129,16 @@ impl<S: hyper::rt::Read + Unpin> AsyncRead for CompioStream<S> {
 impl<S: hyper::rt::Write + Unpin> AsyncWrite for CompioStream<S> {
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
         let result =
-            futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_write(cx, buf.as_init()))
+            std::future::poll_fn(|cx| Pin::new(&mut self.0).poll_write(cx, buf.as_init()))
                 .await;
         BufResult(result, buf)
     }
 
     async fn flush(&mut self) -> io::Result<()> {
-        futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_flush(cx)).await
+        std::future::poll_fn(|cx| Pin::new(&mut self.0).poll_flush(cx)).await
     }
 
     async fn shutdown(&mut self) -> io::Result<()> {
-        futures_util::future::poll_fn(|cx| Pin::new(&mut self.0).poll_shutdown(cx)).await
+        std::future::poll_fn(|cx| Pin::new(&mut self.0).poll_shutdown(cx)).await
     }
 }


### PR DESCRIPTION
Closes #46.

Adds a `cyper_axum::ws` module (behind `ws` feature, off by default) as a drop-in replacement for `axum::extract::ws`.

## What's different from axum's ws

- `compio::runtime::spawn` + `SendWrapper` instead of `tokio::spawn`
- `CompioStream` in `cyper-core` bridges hyper's poll-based IO to compio's `AsyncRead`/`AsyncWrite`; `compio-ws` handles WebSocket framing via `WebSocketStream::from_raw_socket` — replaces `TokioIo` + `tokio-tungstenite`
- `WebSocket` uses async `send()`/`recv()`/`close()` methods (like `compio-ws`) instead of `Stream`/`Sink` traits
- No `Send` bounds on `OnFailedUpgrade` or `on_upgrade` callback (compio is single-threaded)
- Dependencies: `compio/ws` + `sha1` + `base64` instead of `tokio-tungstenite`

Message types, `FromRequestParts`, rejection types, protocol negotiation, and close codes are ported from axum 0.8.8.

## Benchmark (localhost echo, single connection, release build)

| Benchmark | cyper-axum | tokio/axum |
|-----------|-----------|-----------|
| 64B echo | 4.69µs/msg (213K msg/s) | 10.19µs/msg (98K msg/s) |
| 1KiB echo | 5.03µs/msg (199K msg/s) | 10.17µs/msg (98K msg/s) |
| 16KiB bin | 9.22µs/msg (3.4 GiB/s) | 12.82µs/msg (2.4 GiB/s) |
| 64KiB bin | 29.45µs/msg (4.2 GiB/s) | 25.16µs/msg (5.0 GiB/s) |
| 256KiB bin | 111.46µs/msg (4.5 GiB/s) | 61.79µs/msg (8.1 GiB/s) |