### PR TITLE
feat(cyper): fix to not build TlsConnector multiple times

### DIFF
--- a/cyper/Cargo.toml
+++ b/cyper/Cargo.toml
@@ -48,7 +48,7 @@ serde = "1"
 serde_json = { version = "1", optional = true }
 serde_urlencoded = "0.7"
 socket2 = { workspace = true, optional = true }
-synchrony = "0.1"
+synchrony = { version = "0.1", features = ["mutex"] }
 thiserror = "2"
 tower-service = { workspace = true }
 url = "2"

--- a/cyper/src/backend.rs
+++ b/cyper/src/backend.rs
@@ -33,13 +33,19 @@ impl Default for TlsBackendInner {
     }
 }
 
+#[cfg(tls)]
+type SharedTlsConnector = Arc<Mutex<Option<Arc<TlsConnector>>>>;
+
+#[cfg(not(tls))]
+type SharedTlsConnector = ();
+
 /// Represents TLS backend options.
 #[derive(Debug, Clone, Default)]
 pub struct TlsBackend {
     #[allow(dead_code)]
     ty: TlsBackendInner,
     accept_invalid_certs: bool,
-    connector: Arc<Mutex<Option<Arc<TlsConnector>>>>,
+    connector: SharedTlsConnector,
 }
 
 impl TlsBackend {

--- a/cyper/src/backend.rs
+++ b/cyper/src/backend.rs
@@ -1,10 +1,12 @@
+#[cfg(feature = "rustls")]
+use compio::rustls;
 #[cfg(tls)]
 use {
     crate::{Error, Result},
     compio::tls::TlsConnector,
+    std::sync::Arc,
+    synchrony::sync::mutex::Mutex,
 };
-#[cfg(feature = "rustls")]
-use {compio::rustls, std::sync::Arc};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -37,6 +39,7 @@ pub struct TlsBackend {
     #[allow(dead_code)]
     ty: TlsBackendInner,
     accept_invalid_certs: bool,
+    connector: Arc<Mutex<Option<Arc<TlsConnector>>>>,
 }
 
 impl TlsBackend {
@@ -46,6 +49,7 @@ impl TlsBackend {
         Self {
             ty: TlsBackendInner::NativeTls,
             accept_invalid_certs: self.accept_invalid_certs,
+            ..Default::default()
         }
     }
 
@@ -55,6 +59,7 @@ impl TlsBackend {
         Self {
             ty: TlsBackendInner::Rustls(None),
             accept_invalid_certs: self.accept_invalid_certs,
+            ..Default::default()
         }
     }
 
@@ -64,12 +69,14 @@ impl TlsBackend {
         Self {
             ty: TlsBackendInner::Rustls(Some(config)),
             accept_invalid_certs: self.accept_invalid_certs,
+            ..Default::default()
         }
     }
 
     /// Sets whether to accept invalid certificates.
     pub fn with_accept_invalid_certs(mut self, accept: bool) -> Self {
         self.accept_invalid_certs = accept;
+        self.connector = Default::default();
         self
     }
 
@@ -79,7 +86,7 @@ impl TlsBackend {
     }
 
     #[cfg(tls)]
-    pub(crate) fn create_connector(&self) -> Result<TlsConnector> {
+    fn build_connector(&self) -> Result<TlsConnector> {
         match &self.ty {
             TlsBackendInner::None => Err(Error::NoTlsBackend),
             #[cfg(feature = "native-tls")]
@@ -177,5 +184,20 @@ impl TlsBackend {
                 }))
             }
         }
+    }
+
+    #[cfg(tls)]
+    pub(crate) async fn connect<T>(&self, f: impl AsyncFnOnce(&TlsConnector) -> T) -> Result<T> {
+        let connector = {
+            let mut cache = self.connector.lock().await;
+            match &*cache {
+                Some(connector) => connector.clone(),
+                None => {
+                    let new = Arc::new(self.build_connector()?);
+                    cache.get_or_insert(new).clone()
+                }
+            }
+        };
+        Ok(f(&connector).await)
     }
 }

--- a/cyper/src/stream.rs
+++ b/cyper/src/stream.rs
@@ -57,8 +57,8 @@ impl HttpStream {
             "https" => {
                 let port = port.unwrap_or(443);
                 let stream = Self::connect_tcp(&uri, host, port, resolver).await?;
-                let connector = tls.create_connector()?;
-                HyperStream::new_tls(connector.connect(host, stream).await?)
+                let fut = tls.connect(async |connector| connector.connect(host, stream).await);
+                HyperStream::new_tls(fut.await??)
             }
             _ => return Err(Error::BadScheme(scheme.to_string())),
         };
@@ -128,8 +128,8 @@ where
                     .strip_prefix('[')
                     .and_then(|h| h.strip_suffix(']'))
                     .unwrap_or(host);
-                let connector = tls.create_connector()?;
-                HyperStream::new_tls(connector.connect(host, stream).await?)
+                let fut = tls.connect(async |connector| connector.connect(host, stream).await);
+                HyperStream::new_tls(fut.await??)
             }
             _ => return Err(Error::BadScheme(scheme.to_string())),
         };


### PR DESCRIPTION
这Arc套Arc确实有点难看 不过不动public api只能写成这样了
至少性能比每次都build一下好 hot path也就多两个原子操作