### PR TITLE
feat(cyper)!: create tls connector on build

### DIFF
--- a/cyper/examples/client.rs
+++ b/cyper/examples/client.rs
@@ -30,7 +30,7 @@ async fn main() {
     } else {
         Version::HTTP_11
     };
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let response = client
         .get(opts.url)
         .unwrap()

--- a/cyper/src/backend.rs
+++ b/cyper/src/backend.rs
@@ -1,10 +1,8 @@
-#[cfg(tls)]
-use {
-    crate::{Error, Result},
-    compio::tls::TlsConnector,
-};
+use compio::tls::TlsConnector;
 #[cfg(feature = "rustls")]
 use {compio::rustls, std::sync::Arc};
+
+use crate::{Error, Result};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -78,7 +76,6 @@ impl TlsBackend {
         self.accept_invalid_certs
     }
 
-    #[cfg(tls)]
     pub(crate) fn create_connector(&self) -> Result<TlsConnector> {
         match &self.ty {
             TlsBackendInner::None => Err(Error::NoTlsBackend),

--- a/cyper/src/client.rs
+++ b/cyper/src/client.rs
@@ -27,8 +27,7 @@ pub struct Client {
 
 impl Client {
     /// Create a client with default config.
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self> {
         ClientBuilder::new().build()
     }
 
@@ -496,7 +495,7 @@ impl ClientBuilder {
     }
 
     /// Returns a `Client` that uses this `ClientBuilder` configuration.
-    pub fn build(self) -> Client {
+    pub fn build(self) -> Result<Client> {
         #[allow(unused)]
         let accept_invalid_certs = self.tls.accept_invalid_certs();
         let proxies = if self.no_proxy {
@@ -506,14 +505,15 @@ impl ClientBuilder {
         } else {
             Shared::new(vec![proxy::Matcher::system()])
         };
+        let tls = match self.tls.create_connector() {
+            Ok(tls) => Some(tls),
+            Err(crate::Error::NoTlsBackend) => None,
+            Err(e) => return Err(e),
+        };
         let client = hyper_util::client::legacy::Client::builder(CompioExecutor)
             .set_host(true)
             .timer(CompioTimer)
-            .build(Connector::new(
-                self.tls,
-                self.resolver.clone(),
-                proxies.clone(),
-            ));
+            .build(Connector::new(tls, self.resolver.clone(), proxies.clone()));
 
         let proxies_maybe_http_auth = proxies.iter().any(|p| p.maybe_has_http_auth());
         let proxies_maybe_http_custom_headers =
@@ -530,13 +530,13 @@ impl ClientBuilder {
             cookies: self.cookies,
             accepts: self.accepts.header_value(),
         };
-        Client {
+        Ok(Client {
             client: Shared::new(client_ref),
             #[cfg(feature = "http3")]
             h3_client: crate::http3::Client::new(accept_invalid_certs, self.resolver),
             #[cfg(feature = "http3-altsvc")]
             h3_hosts: crate::altsvc::KnownHosts::default(),
-        }
+        })
     }
 
     /// Set the default headers for every request.

--- a/cyper/src/connector.rs
+++ b/cyper/src/connector.rs
@@ -4,12 +4,13 @@ use std::{
     task::{Context, Poll},
 };
 
+use compio::tls::TlsConnector;
 use hyper::Uri;
 use send_wrapper::SendWrapper;
 use tower_service::Service;
 
 use crate::{
-    HttpStream, TlsBackend, WrappedHttpStream,
+    HttpStream, WrappedHttpStream,
     proxy::{self, Intercepted},
     resolve::SharedResolver,
     sync::shared::Shared,
@@ -28,7 +29,7 @@ pub struct Connector {
 impl Connector {
     /// Creates the connector with specific TLS backend.
     pub fn new(
-        tls: TlsBackend,
+        tls: Option<TlsConnector>,
         resolver: Option<SharedResolver>,
         proxies: Shared<Vec<proxy::Matcher>>,
     ) -> Self {
@@ -113,12 +114,12 @@ async fn connect_via_proxy(
 
 #[derive(Debug, Clone)]
 struct HttpsConnector {
-    tls: TlsBackend,
+    tls: Option<TlsConnector>,
     resolver: Option<SharedResolver>,
 }
 
 impl HttpsConnector {
-    pub fn new(tls: TlsBackend, resolver: Option<SharedResolver>) -> Self {
+    pub fn new(tls: Option<TlsConnector>, resolver: Option<SharedResolver>) -> Self {
         Self { tls, resolver }
     }
 }

--- a/cyper/src/nyquest/mod.rs
+++ b/cyper/src/nyquest/mod.rs
@@ -52,7 +52,7 @@ impl CyperBackend {
         }
         #[cfg(feature = "cookies")]
         let builder = builder.cookie_store(options.use_cookies);
-        let client = builder.build();
+        let client = builder.build()?;
         let base_url = if let Some(url) = options.base_url {
             Some(Url::parse(&url).map_err(|_| NyquestError::InvalidUrl)?)
         } else {

--- a/cyper/src/request.rs
+++ b/cyper/src/request.rs
@@ -163,7 +163,7 @@ impl RequestBuilder {
     /// # use cyper::Error;
     ///
     /// # async fn run() -> Result<(), Error> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let resp = client
     ///     .delete("http://httpbin.org/delete")?
     ///     .basic_auth("admin", Some("good password"))?
@@ -264,7 +264,7 @@ impl RequestBuilder {
     /// let mut params = HashMap::new();
     /// params.insert("lang", "rust");
     ///
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let res = client
     ///     .post("http://httpbin.org")?
     ///     .form(&params)?

--- a/cyper/src/response.rs
+++ b/cyper/src/response.rs
@@ -99,7 +99,7 @@ impl Response {
     ///
     /// ```
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let content = client
     ///     .get("http://httpbin.org/range/26")?
     ///     .send()
@@ -132,7 +132,7 @@ impl Response {
     ///
     /// ```
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let content = client
     ///     .get("http://httpbin.org/range/26")?
     ///     .send()
@@ -184,7 +184,7 @@ impl Response {
     /// }
     ///
     /// # async fn run() -> Result<(), Error> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let ip = client
     ///     .get("http://httpbin.org/ip")?
     ///     .send()
@@ -231,7 +231,7 @@ impl Response {
     ///
     /// ```
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let bytes = client
     ///     .get("http://httpbin.org/ip")?
     ///     .send()
@@ -255,7 +255,7 @@ impl Response {
     /// use futures_util::StreamExt;
     ///
     /// # async fn run() -> cyper::Result<()> {
-    /// let client = cyper::Client::new();
+    /// let client = cyper::Client::new().unwrap();
     /// let mut bytes_stream = client
     ///     .get("http://httpbin.org/stream-bytes/16777216")?
     ///     .send()

--- a/cyper/src/stream.rs
+++ b/cyper/src/stream.rs
@@ -10,13 +10,14 @@ use compio::{
     buf::{IoBuf, IoBufMut, IoVectoredBuf},
     io::{AsyncRead, AsyncWrite, util::Splittable},
     net::TcpStream,
+    tls::TlsConnector,
 };
 use cyper_core::HyperStream;
 use futures_util::StreamExt;
 use hyper::Uri;
 use hyper_util::client::legacy::connect::{Connected, Connection};
 
-use crate::{Error, Result, TlsBackend, resolve::SharedResolver};
+use crate::{Error, Result, resolve::SharedResolver};
 
 /// A HTTP stream wrapper, based on compio, and exposes [`hyper::rt`]
 /// interfaces.
@@ -33,7 +34,7 @@ impl HttpStream {
     /// Create [`HttpStream`] with target uri and TLS backend.
     pub async fn connect(
         uri: Uri,
-        tls: TlsBackend,
+        tls: Option<TlsConnector>,
         resolver: Option<SharedResolver>,
         is_proxy: bool,
     ) -> Result<Self> {
@@ -57,7 +58,7 @@ impl HttpStream {
             "https" => {
                 let port = port.unwrap_or(443);
                 let stream = Self::connect_tcp(&uri, host, port, resolver).await?;
-                let connector = tls.create_connector()?;
+                let connector = tls.ok_or_else(|| Error::NoTlsBackend)?;
                 HyperStream::new_tls(connector.connect(host, stream).await?)
             }
             _ => return Err(Error::BadScheme(scheme.to_string())),
@@ -113,7 +114,7 @@ where
     S::ReadHalf: AsyncRead + Unpin,
     S::WriteHalf: AsyncWrite + Unpin,
 {
-    pub async fn connect_with(stream: S, uri: Uri, tls: TlsBackend) -> Result<Self> {
+    pub async fn connect_with(stream: S, uri: Uri, tls: Option<TlsConnector>) -> Result<Self> {
         let scheme = uri.scheme_str().unwrap_or("http");
         let stream = match scheme {
             "http" => {
@@ -128,7 +129,7 @@ where
                     .strip_prefix('[')
                     .and_then(|h| h.strip_suffix(']'))
                     .unwrap_or(host);
-                let connector = tls.create_connector()?;
+                let connector = tls.ok_or_else(|| Error::NoTlsBackend)?;
                 HyperStream::new_tls(connector.connect(host, stream).await?)
             }
             _ => return Err(Error::BadScheme(scheme.to_string())),

--- a/cyper/src/stream.rs
+++ b/cyper/src/stream.rs
@@ -103,6 +103,7 @@ impl HttpStream {
     }
 }
 
+#[cfg(tls)]
 impl HttpStream<HttpStream> {
     pub fn into_wrapped(self) -> WrappedHttpStream {
         WrappedHttpStream::Embedded(self)

--- a/cyper/tests/client.rs
+++ b/cyper/tests/client.rs
@@ -149,6 +149,7 @@ async fn service() {
 }
 
 #[compio::test]
+#[cfg(tls)]
 async fn test_allowed_methods() {
     let resp = Client::new()
         .unwrap()

--- a/cyper/tests/client.rs
+++ b/cyper/tests/client.rs
@@ -11,7 +11,7 @@ use http::header::CONTENT_TYPE;
 async fn response_text() {
     let server = server::http(move |_req| async { "Hello" }).await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/text", server.addr()))
@@ -28,7 +28,7 @@ async fn response_text() {
 async fn response_bytes() {
     let server = server::http(move |_req| async { "Hello" }).await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/bytes", server.addr()))
@@ -76,7 +76,7 @@ async fn response_bytes_stream() {
     let server =
         server::http(move |_req| async { Body::from_stream(ChunkedBody::default()) }).await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/bytes", server.addr()))
@@ -105,7 +105,7 @@ async fn response_bytes_stream() {
 async fn response_json() {
     let server = server::http(move |_req| async { "\"Hello\"" }).await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/json", server.addr()))
@@ -126,7 +126,7 @@ async fn service() {
 
     let server = server::http(move |_req| async { "Hello" }).await;
 
-    let mut client = Client::new();
+    let mut client = Client::new().unwrap();
 
     let request = http::Request::builder()
         .method(Method::GET)
@@ -150,7 +150,12 @@ async fn service() {
 
 #[compio::test]
 async fn test_allowed_methods() {
-    let resp = Client::new().get("https://compio.rs").unwrap().send().await;
+    let resp = Client::new()
+        .unwrap()
+        .get("https://compio.rs")
+        .unwrap()
+        .send()
+        .await;
 
     assert!(resp.is_ok());
 }
@@ -161,6 +166,7 @@ async fn test_native_tls() {
     let resp = Client::builder()
         .use_native_tls()
         .build()
+        .unwrap()
         .get("https://compio.rs")
         .unwrap()
         .send()
@@ -175,6 +181,7 @@ async fn test_rustls() {
     let resp = Client::builder()
         .use_rustls_default()
         .build()
+        .unwrap()
         .get("https://compio.rs")
         .unwrap()
         .send()
@@ -188,6 +195,7 @@ async fn test_rustls() {
 async fn test_http3() {
     let resp = Client::builder()
         .build()
+        .unwrap()
         .get("https://compio.rs")
         .unwrap()
         .version(http::Version::HTTP_3)
@@ -204,6 +212,7 @@ fn add_json_default_content_type_if_not_set_manually() {
     map.insert("body", "json");
     let content_type = http::HeaderValue::from_static("application/vnd.api+json");
     let req = Client::new()
+        .unwrap()
         .post("https://compio.rs/")
         .expect("cannot create request builder")
         .header(CONTENT_TYPE, &content_type)
@@ -221,6 +230,7 @@ fn update_json_content_type_if_set_manually() {
     let mut map = HashMap::new();
     map.insert("body", "json");
     let req = Client::new()
+        .unwrap()
         .post("https://compio.rs/")
         .expect("cannot create request builder")
         .json(&map)
@@ -239,7 +249,7 @@ pub async fn accept_encoding_header_is_not_changed_if_set() {
     })
     .await;
 
-    let client = cyper::Client::new();
+    let client = Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/accept-encoding", server.addr()))

--- a/cyper/tests/cookie.rs
+++ b/cyper/tests/cookie.rs
@@ -24,7 +24,7 @@ async fn cookie_response_accessor() {
     })
     .await;
 
-    let client = cyper::Client::new();
+    let client = cyper::Client::new().unwrap();
 
     let url = format!("http://{}/", server.addr());
     let res = client.get(&url).unwrap().send().await.unwrap();
@@ -86,7 +86,7 @@ async fn cookie_store_simple() {
     })
     .await;
 
-    let client = cyper::Client::builder().cookie_store(true).build();
+    let client = cyper::Client::builder().cookie_store(true).build().unwrap();
 
     let url = format!("http://{}/", server.addr());
     client.get(&url).unwrap().send().await.unwrap();
@@ -111,7 +111,7 @@ async fn cookie_store_overwrite_existing() {
     })
     .await;
 
-    let client = cyper::Client::builder().cookie_store(true).build();
+    let client = cyper::Client::builder().cookie_store(true).build().unwrap();
 
     let url = format!("http://{}/", server.addr());
     client.get(&url).unwrap().send().await.unwrap();
@@ -131,7 +131,7 @@ async fn cookie_store_max_age() {
     })
     .await;
 
-    let client = cyper::Client::builder().cookie_store(true).build();
+    let client = cyper::Client::builder().cookie_store(true).build().unwrap();
     let url = format!("http://{}/", server.addr());
     client.get(&url).unwrap().send().await.unwrap();
     client.get(&url).unwrap().send().await.unwrap();
@@ -145,7 +145,7 @@ async fn cookie_store_expires() {
     })
     .await;
 
-    let client = cyper::Client::builder().cookie_store(true).build();
+    let client = cyper::Client::builder().cookie_store(true).build().unwrap();
 
     let url = format!("http://{}/", server.addr());
     client.get(&url).unwrap().send().await.unwrap();
@@ -166,7 +166,7 @@ async fn cookie_store_path() {
     })
     .await;
 
-    let client = cyper::Client::builder().cookie_store(true).build();
+    let client = cyper::Client::builder().cookie_store(true).build().unwrap();
 
     let url = format!("http://{}/", server.addr());
     client.get(&url).unwrap().send().await.unwrap();

--- a/cyper/tests/decompression/mod.rs
+++ b/cyper/tests/decompression/mod.rs
@@ -57,7 +57,7 @@ pub async fn compressed_response<C: Compress>(response_size: usize, chunk_size: 
     })
     .await;
 
-    let client = cyper::Client::new();
+    let client = cyper::Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/{encoding}", server.addr()))
@@ -85,7 +85,7 @@ pub async fn compressed_empty_body<C: Compress>() {
     })
     .await;
 
-    let client = cyper::Client::new();
+    let client = cyper::Client::new().unwrap();
     let res = client
         .head(format!("http://{}/{encoding}", server.addr()))
         .unwrap()
@@ -113,7 +113,7 @@ pub async fn accept_header_is_not_changed_if_set<C: Compress>() {
     })
     .await;
 
-    let client = cyper::Client::new();
+    let client = cyper::Client::new().unwrap();
 
     let res = client
         .get(format!("http://{}/accept", server.addr()))

--- a/cyper/tests/multipart.rs
+++ b/cyper/tests/multipart.rs
@@ -40,6 +40,7 @@ async fn text_part() {
     let url = format!("http://{}/multipart/1", server.addr());
 
     let res = cyper::Client::new()
+        .unwrap()
         .post(&url)
         .unwrap()
         .multipart(form)
@@ -96,7 +97,7 @@ async fn stream_part() {
 
     let url = format!("http://{}/multipart/1", server.addr());
 
-    let client = cyper::Client::new();
+    let client = cyper::Client::new().unwrap();
 
     let res = client
         .post(&url)
@@ -152,6 +153,7 @@ async fn async_impl_file_part() {
     let url = format!("http://{}/multipart/3", server.addr());
 
     let res = cyper::Client::new()
+        .unwrap()
         .post(&url)
         .unwrap()
         .multipart(form)

--- a/cyper/tests/proxy.rs
+++ b/cyper/tests/proxy.rs
@@ -25,7 +25,8 @@ async fn http_proxy() {
     let proxy_url = format!("http://{}", server.addr());
     let client = Client::builder()
         .proxy(Proxy::http(&proxy_url).unwrap())
-        .build();
+        .build()
+        .unwrap();
 
     let res = client
         .get("http://cyper.local/prox")
@@ -58,7 +59,8 @@ async fn http_proxy_basic_auth() {
                 .unwrap()
                 .basic_auth("Aladdin", "open sesame"),
         )
-        .build();
+        .build()
+        .unwrap();
 
     let res = client
         .get("http://cyper.local/prox")
@@ -87,7 +89,8 @@ async fn http_proxy_basic_auth_parsed() {
     let proxy_url = format!("http://Aladdin:open sesame@{}", server.addr());
     let client = Client::builder()
         .proxy(Proxy::http(&proxy_url).unwrap())
-        .build();
+        .build()
+        .unwrap();
 
     let res = client
         .get("http://cyper.local/prox")
@@ -116,7 +119,8 @@ async fn http_proxy_custom_auth_header() {
                 .unwrap()
                 .custom_http_auth(http::HeaderValue::from_static("testme")),
         )
-        .build();
+        .build()
+        .unwrap();
 
     let res = client
         .get("http://cyper.local/prox")
@@ -147,7 +151,8 @@ async fn test_no_proxy() {
         .proxy(Proxy::http(&proxy_url).unwrap().no_proxy(Some(
             NoProxy::from_string(&server.addr().ip().to_string()).unwrap(),
         )))
-        .build();
+        .build()
+        .unwrap();
 
     // Request to the same server; should bypass proxy and go direct
     let url = format!("http://{}/4", server.addr());
@@ -170,7 +175,8 @@ async fn tunnel_detects_unsuccessful() {
     let client = Client::builder()
         .proxy(Proxy::https(&proxy_url).unwrap())
         .danger_accept_invalid_certs(true)
-        .build();
+        .build()
+        .unwrap();
 
     let err = client
         .get("https://cyper.local/prox")
@@ -210,7 +216,8 @@ async fn tunnel_includes_proxy_auth() {
     let client = Client::builder()
         .proxy(Proxy::https(&proxy_url).unwrap())
         .danger_accept_invalid_certs(true)
-        .build();
+        .build()
+        .unwrap();
 
     let err = client
         .get("https://cyper.local/prox")
@@ -243,7 +250,8 @@ async fn proxy_https_matches_https_only() {
     let proxy_url = format!("http://{}", server.addr());
     let client = Client::builder()
         .proxy(Proxy::https(&proxy_url).unwrap())
-        .build();
+        .build()
+        .unwrap();
 
     // An HTTP request should NOT go through the HTTPS proxy
     let res = client.get("http://cyper.local/prox").unwrap().send().await;
@@ -268,7 +276,8 @@ async fn proxy_multiple_matches_correct() {
     let client = Client::builder()
         .proxy(Proxy::https("http://unreachable.example").unwrap())
         .proxy(Proxy::http(&proxy_url).unwrap())
-        .build();
+        .build()
+        .unwrap();
 
     let res = client
         .get("http://cyper.local/prox")

--- a/cyper/tests/redirect.rs
+++ b/cyper/tests/redirect.rs
@@ -25,7 +25,7 @@ async fn test_redirect_follow() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
 
     for path in [
         "/redirect301",
@@ -60,7 +60,7 @@ async fn test_redirect_chain() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let res = client
         .get(format!("http://{}/step/1", server.addr()))
         .unwrap()
@@ -87,7 +87,8 @@ async fn test_redirect_limit() {
 
     let client = Client::builder()
         .redirect(redirect::Policy::limited(5))
-        .build();
+        .build()
+        .unwrap();
 
     let err = client
         .get(format!("http://{}/loop", server.addr()))
@@ -107,7 +108,10 @@ async fn test_no_redirect() {
     })
     .await;
 
-    let client = Client::builder().redirect(redirect::Policy::none()).build();
+    let client = Client::builder()
+        .redirect(redirect::Policy::none())
+        .build()
+        .unwrap();
 
     let res = client
         .get(format!("http://{}/redirect", server.addr()))
@@ -138,7 +142,8 @@ async fn test_redirect_custom_policy() {
                 attempt.follow()
             }
         }))
-        .build();
+        .build()
+        .unwrap();
 
     // Should stop at the redirect because our custom policy
     // stops when the target is /target
@@ -170,7 +175,7 @@ async fn test_redirect_with_query() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let res = client
         .get(format!("http://{}/redirect", server.addr()))
         .unwrap()
@@ -194,7 +199,7 @@ async fn test_redirect_relative_url() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let res = client
         .get(format!("http://{}/a", server.addr()))
         .unwrap()
@@ -224,7 +229,7 @@ async fn test_redirect_body_for_307() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let res = client
         .post(format!("http://{}/redirect", server.addr()))
         .unwrap()
@@ -252,7 +257,7 @@ async fn test_redirect_method_change_on_301() {
     })
     .await;
 
-    let client = Client::new();
+    let client = Client::new().unwrap();
     let res = client
         .post(format!("http://{}/redirect", server.addr()))
         .unwrap()

--- a/cyper/tests/resolve.rs
+++ b/cyper/tests/resolve.rs
@@ -20,7 +20,10 @@ impl Resolve for TestResolver {
 async fn resolve() {
     let server = server::http(move |_req| async { "Hello" }).await;
 
-    let client = Client::builder().custom_resolver(TestResolver).build();
+    let client = Client::builder()
+        .custom_resolver(TestResolver)
+        .build()
+        .unwrap();
 
     let res = client
         .get(format!("http://abc:{}/text", server.addr().port()))


### PR DESCRIPTION
cc: @revonateB0T

I changed the methods `ClientBuilder::build` and `Client::new` to return `Result`.

`reqwest` also returns `Result` in `ClientBuilder::build`, but panics in `Client::new`. I don't like that design.

Closes #62 