### PR TITLE
perf(cyper-axum): avoid buffered TCP compatibility I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/compio-rs/cyper"
 
 [workspace.dependencies]
-compio = { version = "0.19.0", default-features = false }
+compio = { version = "0.19.1", default-features = false }
 compio-log = "0.2.0"
 
 cyper-core = { path = "./cyper-core", default-features = false, version = "0.9.0" }

--- a/cyper-axum/src/lib.rs
+++ b/cyper-axum/src/lib.rs
@@ -54,6 +54,11 @@ pub trait Listener: 'static {
 
     /// Returns the local address that this listener is bound to.
     fn local_addr(&self) -> io::Result<Self::Addr>;
+
+    /// Converts an accepted connection into an IO type used by hyper.
+    fn into_hyper_stream(io: Self::Io) -> HyperStream<Self::Io> {
+        HyperStream::new_plain(io)
+    }
 }
 
 impl Listener for TcpListener {
@@ -71,6 +76,33 @@ impl Listener for TcpListener {
 
     fn local_addr(&self) -> io::Result<Self::Addr> {
         Self::local_addr(self)
+    }
+
+    fn into_hyper_stream(io: Self::Io) -> HyperStream<Self::Io> {
+        // Reuse the socket's shared descriptor instead of duplicating it, so
+        // hyper writes to the socket directly rather than through the
+        // Compio-to-futures adapter and its intermediate buffer. Vectored
+        // writes and TCP half-close are preserved.
+        //
+        // The non-blocking flag belongs to the socket, so every handle to it
+        // observes the change. Set it while the just-accepted `io` is the only
+        // handle and no `PollFd` exists yet. On failure `io` is untouched and
+        // the buffered path still works.
+        match socket2::SockRef::from(&io)
+            .set_nonblocking(true)
+            .and_then(|()| io.to_poll_fd())
+        {
+            Ok(poll_fd) => {
+                // `poll_fd` shares the descriptor with `io`. Release `io` here so the
+                // readiness path owns the only remaining handle to it.
+                drop(io);
+                HyperStream::new_plain_compat(poll_fd, true)
+            }
+            Err(error) => {
+                warn!("failed to enable readiness-based TCP IO; using buffered IO: {error}");
+                HyperStream::new_plain(io)
+            }
+        }
     }
 }
 
@@ -285,7 +317,7 @@ where
             loop {
                 let (io, remote_addr) = listener.accept().await;
 
-                let io = HyperStream::new_plain(io);
+                let io = L::into_hyper_stream(io);
 
                 poll_fn(|cx| make_service.poll_ready(cx))
                     .await
@@ -416,7 +448,7 @@ where
                     }
                 };
 
-                let io = HyperStream::new_plain(io);
+                let io = L::into_hyper_stream(io);
 
                 trace!("connection {remote_addr:?} accepted");
 
@@ -595,5 +627,45 @@ impl<R, T: hyper::service::Service<R>> hyper::service::Service<R> for ServiceSen
 
     fn call(&self, req: R) -> Self::Future {
         SendWrapper::new(self.0.call(req))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{IoSlice, Read as _},
+        net::Ipv4Addr,
+        time::Duration,
+    };
+
+    use futures_util::AsyncWriteExt as _;
+
+    use super::*;
+
+    #[compio::test]
+    async fn compat_tcp_vectored_write_and_half_close() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
+            .await
+            .unwrap();
+        let mut client = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        let poll_fd = server.to_poll_fd().unwrap();
+        poll_fd.set_nonblocking(true).unwrap();
+        drop(server);
+        let mut stream = HyperStream::<TcpStream>::new_plain_compat(poll_fd, true);
+
+        assert!(hyper::rt::Write::is_write_vectored(&stream));
+        let bufs = [IoSlice::new(b"hello "), IoSlice::new(b"world")];
+        let written = stream.write_vectored(&bufs).await.unwrap();
+        assert!(written > 0);
+        stream.write_all(&b"hello world"[written..]).await.unwrap();
+        stream.close().await.unwrap();
+
+        let mut received = Vec::new();
+        client.read_to_end(&mut received).unwrap();
+        assert_eq!(received, b"hello world");
     }
 }

--- a/cyper-axum/src/ws.rs
+++ b/cyper-axum/src/ws.rs
@@ -32,20 +32,27 @@
 //! # let _: Router = app;
 //! ```
 
-use std::{borrow::Cow, collections::BTreeSet, future::Future};
+use std::{
+    borrow::Cow,
+    collections::BTreeSet,
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use async_tungstenite::{
     WebSocketStream,
     tungstenite::{self as ts, protocol::WebSocketConfig},
 };
 use axum_core::{body::Body, extract::FromRequestParts, response::Response};
+use cyper_core::HyperStream;
 use futures_util::StreamExt;
 use hyper::{
     Method, StatusCode, Version,
     header::{self, HeaderMap, HeaderName, HeaderValue},
     http::request::Parts,
 };
-use send_wrapper::SendWrapper;
 use sha1::{Digest, Sha1};
 // Re-export tungstenite types for convenience.
 pub use ts::protocol::frame::coding::CloseCode;
@@ -59,7 +66,7 @@ use self::{compat::FuturesIo, rejection::*};
 ///
 /// Use [`recv`](Self::recv) and [`send`](Self::send) to communicate.
 pub struct WebSocket {
-    inner: WebSocketStream<FuturesIo<hyper::upgrade::Upgraded>>,
+    inner: WebSocketStream<UpgradedIo>,
     protocol: Option<HeaderValue>,
 }
 
@@ -281,7 +288,7 @@ impl<F> WebSocketUpgrade<F> {
         let on_failed_upgrade = self.on_failed_upgrade;
         let protocol = self.protocol.clone();
 
-        compio::runtime::spawn(SendWrapper::new(async move {
+        compio::runtime::spawn(async move {
             let upgraded = match on_upgrade.await {
                 Ok(upgraded) => upgraded,
                 Err(err) => {
@@ -290,7 +297,13 @@ impl<F> WebSocketUpgrade<F> {
                 }
             };
 
-            let upgraded = FuturesIo::new(upgraded);
+            let upgraded = match hyper_util::server::conn::auto::upgrade::downcast::<
+                Pin<Box<HyperStream<compio::net::TcpStream>>>,
+            >(upgraded)
+            {
+                Ok(parts) => UpgradedIo::Direct(RewindIo::new(parts.io, parts.read_buf)),
+                Err(upgraded) => UpgradedIo::Fallback(FuturesIo::new(upgraded)),
+            };
             let ws = WebSocketStream::from_raw_socket(
                 upgraded,
                 ts::protocol::Role::Server,
@@ -302,7 +315,7 @@ impl<F> WebSocketUpgrade<F> {
                 protocol,
             };
             callback(socket).await;
-        }))
+        })
         .detach();
 
         let mut response = if let Some(sec_websocket_key) = &self.sec_websocket_key {
@@ -446,6 +459,117 @@ fn sign(key: &[u8]) -> HeaderValue {
     HeaderValue::from_maybe_shared(b64).expect("base64 is a valid value")
 }
 
+type DirectIo = RewindIo<Pin<Box<HyperStream<compio::net::TcpStream>>>>;
+
+enum UpgradedIo {
+    Direct(DirectIo),
+    Fallback(FuturesIo<hyper::upgrade::Upgraded>),
+}
+
+impl futures_util::AsyncRead for UpgradedIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            Self::Direct(io) => Pin::new(io).poll_read(cx, buf),
+            Self::Fallback(io) => Pin::new(io).poll_read(cx, buf),
+        }
+    }
+}
+
+impl futures_util::AsyncWrite for UpgradedIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            Self::Direct(io) => Pin::new(io).poll_write(cx, buf),
+            Self::Fallback(io) => Pin::new(io).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            Self::Direct(io) => Pin::new(io).poll_write_vectored(cx, bufs),
+            Self::Fallback(io) => Pin::new(io).poll_write_vectored(cx, bufs),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Self::Direct(io) => Pin::new(io).poll_flush(cx),
+            Self::Fallback(io) => Pin::new(io).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Self::Direct(io) => Pin::new(io).poll_close(cx),
+            Self::Fallback(io) => Pin::new(io).poll_close(cx),
+        }
+    }
+}
+
+struct RewindIo<T> {
+    inner: T,
+    prefix: ts::Bytes,
+}
+
+impl<T> RewindIo<T> {
+    fn new(inner: T, prefix: ts::Bytes) -> Self {
+        Self { inner, prefix }
+    }
+}
+
+impl<T: futures_util::AsyncRead + Unpin> futures_util::AsyncRead for RewindIo<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        if !self.prefix.is_empty() {
+            let len = self.prefix.len().min(buf.len());
+            buf[..len].copy_from_slice(&self.prefix[..len]);
+            self.prefix = self.prefix.slice(len..);
+            return Poll::Ready(Ok(len));
+        }
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<T: futures_util::AsyncWrite + Unpin> futures_util::AsyncWrite for RewindIo<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
 mod compat {
     use std::{
         io,
@@ -467,8 +591,8 @@ mod compat {
             cx: &mut Context<'_>,
             buf: &mut [u8],
         ) -> Poll<io::Result<usize>> {
-            // Since `buf` is fully initialized, we use `ReadBuf::new` to store that info in the
-            // `init` field of `ReadBuf`.
+            // Since `buf` is fully initialized, we use `ReadBuf::new` to store that info in
+            // the `init` field of `ReadBuf`.
             let mut read_buf = hyper::rt::ReadBuf::new(buf);
             ready!(hyper::rt::Read::poll_read(
                 Pin::new(&mut self.0),
@@ -503,6 +627,182 @@ mod compat {
         fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             hyper::rt::Write::poll_shutdown(Pin::new(&mut self.0), cx)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::{AsyncRead as _, io::Cursor};
+
+    use super::*;
+
+    #[test]
+    fn websocket_is_send() {
+        fn assert_send<T: Send>() {}
+
+        // `SendWrapper` enforces thread affinity at runtime and will panic if the
+        // WebSocket is accessed or dropped from a different thread.
+        assert_send::<WebSocket>();
+    }
+
+    mod tcp {
+        use std::{net::Ipv4Addr, time::Duration};
+
+        use axum::{Router, routing::any};
+        use compio::net::{TcpListener, TcpStream};
+        use futures_channel::oneshot;
+
+        use super::super::*;
+
+        async fn echo_upgrade(ws: WebSocketUpgrade) -> axum_core::response::Response {
+            ws.on_upgrade(|mut socket| async move {
+                while let Some(Ok(message)) = socket.recv().await {
+                    if socket.send(message).await.is_err() {
+                        break;
+                    }
+                }
+            })
+        }
+
+        #[compio::test]
+        async fn tcp_upgrade_uses_compat_io() {
+            use std::sync::{
+                Arc,
+                atomic::{AtomicBool, Ordering},
+            };
+
+            use compio::ws::tungstenite::Message as ClientMessage;
+
+            let uses_compat_io = Arc::new(AtomicBool::new(false));
+            let observed = Arc::clone(&uses_compat_io);
+            let app = Router::new().route(
+                "/ws",
+                any(move |ws: WebSocketUpgrade| {
+                    let observed = Arc::clone(&observed);
+                    async move {
+                        ws.on_upgrade(move |mut socket| async move {
+                            observed.store(
+                                matches!(
+                                    socket.inner.get_ref(),
+                                    UpgradedIo::Direct(io)
+                                        if io.inner.as_ref().get_ref().uses_compat_io()
+                                ),
+                                Ordering::SeqCst,
+                            );
+                            if let Some(Ok(message)) = socket.recv().await {
+                                socket.send(message).await.unwrap();
+                            }
+                        })
+                    }
+                }),
+            );
+            let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
+                .await
+                .unwrap();
+            let addr = listener.local_addr().unwrap();
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            compio::runtime::spawn(async move {
+                crate::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        shutdown_rx.await.ok();
+                    })
+                    .await
+                    .unwrap();
+            })
+            .detach();
+
+            let stream = TcpStream::connect(addr).await.unwrap();
+            let (mut client, _) = compio::ws::client_async(format!("ws://{addr}/ws"), stream)
+                .await
+                .unwrap();
+            client
+                .send(ClientMessage::Text("probe".into()))
+                .await
+                .unwrap();
+            assert_eq!(
+                client.read().await.unwrap(),
+                ClientMessage::Text("probe".into())
+            );
+            assert!(uses_compat_io.load(Ordering::SeqCst));
+
+            client.close(None).await.ok();
+            drop(shutdown_tx);
+        }
+
+        /// The client sends the upgrade request and the first WebSocket frame
+        /// in a single write, so hyper reads both in one syscall and
+        /// hands the frame back as pre-read bytes. Losing those bytes
+        /// would silently drop the first frame.
+        #[compio::test]
+        async fn pipelined_first_frame_survives_upgrade() {
+            use compio::io::{AsyncRead as _, AsyncWriteExt as _};
+
+            let app = Router::new().route("/ws", any(echo_upgrade));
+            let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16))
+                .await
+                .unwrap();
+            let addr = listener.local_addr().unwrap();
+            let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+            compio::runtime::spawn(async move {
+                crate::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        shutdown_rx.await.ok();
+                    })
+                    .await
+                    .unwrap();
+            })
+            .detach();
+
+            // A masked single-frame text message carrying "hi".
+            let frame: [u8; 8] = [0x81, 0x82, 0x00, 0x00, 0x00, 0x00, b'h', b'i'];
+            let mut request = format!(
+                "GET /ws HTTP/1.1\r\nHost: {addr}\r\nConnection: Upgrade\r\nUpgrade: \
+                 websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: \
+                 AAAAAAAAAAAAAAAAAAAAAA==\r\n\r\n"
+            )
+            .into_bytes();
+            request.extend_from_slice(&frame);
+
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream.write_all(request).await.0.unwrap();
+
+            let echoed = compio::time::timeout(Duration::from_secs(10), async {
+                let mut response = Vec::new();
+                loop {
+                    let buf = Vec::with_capacity(256);
+                    let (read, buf) = stream.read(buf).await.unwrap();
+                    assert_ne!(read, 0, "server closed before echoing the pipelined frame");
+                    response.extend_from_slice(&buf);
+                    if response.ends_with(&[0x81, 0x02, b'h', b'i']) {
+                        return;
+                    }
+                }
+            })
+            .await;
+            assert!(echoed.is_ok(), "pipelined first frame was never echoed");
+
+            drop(shutdown_tx);
+        }
+    }
+
+    #[test]
+    fn rewind_io_reads_prefix_before_stream() {
+        let mut io = RewindIo::new(Cursor::new(b"stream"), ts::Bytes::from_static(b"prefix"));
+        let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
+        let mut prefix = [0; 6];
+        let mut stream = [0; 6];
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_read(&mut cx, &mut prefix),
+            Poll::Ready(Ok(6))
+        ));
+        assert!(matches!(
+            Pin::new(&mut io).poll_read(&mut cx, &mut stream),
+            Poll::Ready(Ok(6))
+        ));
+
+        assert_eq!(&prefix, b"prefix");
+        assert_eq!(&stream, b"stream");
     }
 }
 

--- a/cyper-core/src/stream.rs
+++ b/cyper-core/src/stream.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    io,
+    fmt, io,
     pin::Pin,
     task::{Context, Poll, ready},
 };
@@ -11,24 +11,73 @@ use compio::{
 };
 use send_wrapper::SendWrapper;
 
+trait CompatIo: futures_util::AsyncRead + futures_util::AsyncWrite + Unpin {}
+
+impl<T> CompatIo for T where T: futures_util::AsyncRead + futures_util::AsyncWrite + Unpin {}
+
+struct CompatStream {
+    io: Pin<Box<dyn CompatIo>>,
+    is_write_vectored: bool,
+}
+
+enum HyperStreamInner<S: Splittable> {
+    Compio(Box<MaybeTlsStream<S>>),
+    Compat(CompatStream),
+}
+
 /// A stream wrapper for hyper.
-#[derive(Debug)]
-pub struct HyperStream<S: Splittable>(SendWrapper<MaybeTlsStream<S>>);
+pub struct HyperStream<S: Splittable>(SendWrapper<HyperStreamInner<S>>);
+
+impl<S: Splittable> fmt::Debug for HyperStream<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HyperStream")
+            .field("is_tls", &self.is_tls())
+            .finish_non_exhaustive()
+    }
+}
 
 impl<S: Splittable> HyperStream<S> {
     /// Create a new [`HyperStream`] from a plain stream.
     pub fn new_plain(s: S) -> Self {
-        Self(SendWrapper::new(MaybeTlsStream::new_plain(s)))
+        Self(SendWrapper::new(HyperStreamInner::Compio(Box::new(
+            MaybeTlsStream::new_plain(s),
+        ))))
+    }
+
+    /// Create a plain [`HyperStream`] using a futures-compatible transport.
+    ///
+    /// `is_write_vectored` must report whether the transport implements
+    /// [`futures_util::AsyncWrite::poll_write_vectored`] efficiently.
+    #[doc(hidden)]
+    pub fn new_plain_compat<T>(s: T, is_write_vectored: bool) -> Self
+    where
+        T: futures_util::AsyncRead + futures_util::AsyncWrite + Unpin + 'static,
+    {
+        Self(SendWrapper::new(HyperStreamInner::Compat(CompatStream {
+            io: Box::pin(s),
+            is_write_vectored,
+        })))
     }
 
     /// Create a new [`HyperStream`] from a TLS stream.
     pub fn new_tls(s: TlsStream<S>) -> Self {
-        Self(SendWrapper::new(MaybeTlsStream::new_tls(s)))
+        Self(SendWrapper::new(HyperStreamInner::Compio(Box::new(
+            MaybeTlsStream::new_tls(s),
+        ))))
     }
 
     /// Whether the stream is TLS-encrypted.
     pub fn is_tls(&self) -> bool {
-        self.0.is_tls()
+        match &*self.0 {
+            HyperStreamInner::Compio(io) => io.is_tls(),
+            HyperStreamInner::Compat(_) => false,
+        }
+    }
+
+    /// Whether this stream uses futures-compatible IO internally.
+    #[doc(hidden)]
+    pub fn uses_compat_io(&self) -> bool {
+        matches!(*self.0, HyperStreamInner::Compat(_))
     }
 }
 
@@ -39,7 +88,10 @@ where
 {
     /// Returns the negotiated ALPN protocol.
     pub fn negotiated_alpn(&self) -> Option<Cow<'_, [u8]>> {
-        self.0.negotiated_alpn()
+        match &*self.0 {
+            HyperStreamInner::Compio(io) => io.negotiated_alpn(),
+            HyperStreamInner::Compat(_) => None,
+        }
     }
 }
 
@@ -54,11 +106,23 @@ where
         mut buf: hyper::rt::ReadBufCursor<'_>,
     ) -> Poll<io::Result<()>> {
         let uninit = buf.initialize_unfilled();
-        let res = ready!(futures_util::AsyncRead::poll_read(
-            Pin::new(&mut *self.0),
-            cx,
-            uninit,
-        ))?;
+        let capacity = uninit.len();
+        let res = match &mut *self.0 {
+            HyperStreamInner::Compio(io) => ready!(futures_util::AsyncRead::poll_read(
+                Pin::new(&mut **io),
+                cx,
+                uninit,
+            ))?,
+            HyperStreamInner::Compat(stream) => ready!(stream.io.as_mut().poll_read(cx, uninit))?,
+        };
+        if res > capacity {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "stream reported more bytes than the read buffer can hold",
+            )));
+        }
+        // SAFETY: `AsyncRead` receives only initialized bytes, and the byte count was
+        // checked against the slice length above.
         unsafe { buf.advance(res) };
         Poll::Ready(Ok(()))
     }
@@ -74,7 +138,12 @@ where
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncRead::poll_read(Pin::new(&mut *self.0), cx, buf)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncRead::poll_read(Pin::new(&mut **io), cx, buf)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_read(cx, buf),
+        }
     }
 
     fn poll_read_vectored(
@@ -82,7 +151,12 @@ where
         cx: &mut Context<'_>,
         bufs: &mut [io::IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncRead::poll_read_vectored(Pin::new(&mut *self.0), cx, bufs)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncRead::poll_read_vectored(Pin::new(&mut **io), cx, bufs)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_read_vectored(cx, bufs),
+        }
     }
 }
 
@@ -96,7 +170,7 @@ where
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncWrite::poll_write(Pin::new(&mut *self.0), cx, buf)
+        futures_util::AsyncWrite::poll_write(Pin::new(&mut *self), cx, buf)
     }
 
     fn poll_write_vectored(
@@ -104,19 +178,22 @@ where
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncWrite::poll_write_vectored(Pin::new(&mut *self.0), cx, bufs)
+        futures_util::AsyncWrite::poll_write_vectored(Pin::new(&mut *self), cx, bufs)
     }
 
     fn is_write_vectored(&self) -> bool {
-        true
+        match &*self.0 {
+            HyperStreamInner::Compio(_) => true,
+            HyperStreamInner::Compat(stream) => stream.is_write_vectored,
+        }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures_util::AsyncWrite::poll_flush(Pin::new(&mut *self.0), cx)
+        futures_util::AsyncWrite::poll_flush(Pin::new(&mut *self), cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures_util::AsyncWrite::poll_close(Pin::new(&mut *self.0), cx)
+        futures_util::AsyncWrite::poll_close(Pin::new(&mut *self), cx)
     }
 }
 
@@ -130,7 +207,12 @@ where
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncWrite::poll_write(Pin::new(&mut *self.0), cx, buf)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncWrite::poll_write(Pin::new(&mut **io), cx, buf)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_write(cx, buf),
+        }
     }
 
     fn poll_write_vectored(
@@ -138,14 +220,81 @@ where
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        futures_util::AsyncWrite::poll_write_vectored(Pin::new(&mut *self.0), cx, bufs)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncWrite::poll_write_vectored(Pin::new(&mut **io), cx, bufs)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_write_vectored(cx, bufs),
+        }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures_util::AsyncWrite::poll_flush(Pin::new(&mut *self.0), cx)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncWrite::poll_flush(Pin::new(&mut **io), cx)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_flush(cx),
+        }
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        futures_util::AsyncWrite::poll_close(Pin::new(&mut *self.0), cx)
+        match &mut *self.0 {
+            HyperStreamInner::Compio(io) => {
+                futures_util::AsyncWrite::poll_close(Pin::new(&mut **io), cx)
+            }
+            HyperStreamInner::Compat(stream) => stream.io.as_mut().poll_close(cx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OverreportingIo;
+
+    impl futures_util::AsyncRead for OverreportingIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len() + 1))
+        }
+    }
+
+    impl futures_util::AsyncWrite for OverreportingIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn rejects_reads_larger_than_the_destination_buffer() {
+        let mut stream =
+            HyperStream::<compio::io::util::Null>::new_plain_compat(OverreportingIo, false);
+        let mut bytes = [0; 8];
+        let mut read_buf = hyper::rt::ReadBuf::new(&mut bytes);
+        let mut cx = Context::from_waker(futures_util::task::noop_waker_ref());
+
+        let result =
+            hyper::rt::Read::poll_read(Pin::new(&mut stream), &mut cx, read_buf.unfilled());
+
+        assert!(matches!(
+            result,
+            Poll::Ready(Err(error)) if error.kind() == io::ErrorKind::InvalidData
+        ));
     }
 }


### PR DESCRIPTION
Uses readiness-based TCP I/O on every platform, where hyper writes to the socket directly instead of going through Compio's futures adapter and its intermediate buffer. Accepted sockets reuse their shared descriptor via `to_poll_fd()`; if that fails the buffered path is kept.

Needs `compio-runtime` 0.12.5 or newer: the vectored-write and half-close impls for `PollFd` from compio#993 landed in 0.12.4, and the Windows readiness fix from compio#999 in 0.12.5. Cargo resolves that by default, but the `compio` facade declares `compio-runtime = "0.12.3"`, so the floor cannot be expressed transitively — a stale lockfile pinned to 0.12.4 will truncate responses on Windows.

Closes #53.

## Latency

Measured on Linux. Single connection, tokio-tungstenite client, 40 000 round trips per series (6 000 at 1 MiB).

![latency distribution](https://raw.githubusercontent.com/Xerxes-2/cyper/assets/bench-plots/ws-latency-distribution.png)

| Payload | server | p50 | p90 | p99 | p99.9 | max |
|---|---|---:|---:|---:|---:|---:|
| 64 B | `master` | 6.77 µs | 7.38 µs | 8.76 µs | 11.30 µs | 45.8 µs |
| | **this PR** | **5.99 µs** | **6.64 µs** | **7.71 µs** | **10.34 µs** | **43.0 µs** |
| | `axum` | 5.96 µs | 6.52 µs | 7.07 µs | 8.43 µs | 20.9 µs |
| 16 KiB | `master` | 12.28 µs | 13.53 µs | 16.88 µs | 33.32 µs | 53.8 µs |
| | **this PR** | **9.16 µs** | **10.15 µs** | **12.52 µs** | **21.73 µs** | **42.1 µs** |
| | `axum` | 7.07 µs | 7.60 µs | 8.05 µs | 10.55 µs | 21.0 µs |
| 1 MiB | `master` | 377.96 µs | 391.71 µs | 427.77 µs | 539.86 µs | 573.6 µs |
| | **this PR** | **149.29 µs** | **154.46 µs** | **203.44 µs** | **248.35 µs** | **286.4 µs** |
| | `axum` | 186.43 µs | 190.86 µs | 197.92 µs | 215.55 µs | 367.3 µs |

Every percentile improves on `master`, including max. At 1 MiB the whole distribution moves left and stays ahead of Axum out to the tail. At 64 B the median is now level with Axum; at 16 KiB a gap remains, and in both cases it is concentrated in the tail rather than the median — the same upward bend shows up at every payload size, which looks more like an occasional extra wakeup than per-byte cost. Worth a follow-up.

## Concurrency

A separate measurement, so small differences from the table above are run-to-run variance.

| Payload × conns | round trips/conn | `master` p50 | this PR p50 | axum p50 | `master` MiB/s | this PR MiB/s |
|---|---:|---:|---:|---:|---:|---:|
| 64 B × 64 | 313 | 265 µs | **224 µs** | 208 µs | 29 | **35** |
| 64 B × 256 | 79 | 877 µs | **304 µs** | 280 µs | 24 | **28** |
| 64 B × 1024 | 20 | 396 µs | **349 µs** | 342 µs | 19 | **22** |
| 16 KiB × 64 | 125 | 494 µs | **253 µs** | 233 µs | 4022 | **7799** |
| 16 KiB × 256 | 32 | 2.21 ms | **316 µs** | 1.09 ms | 3515 | **6780** |
| 16 KiB × 1024 | 8 | 20.55 ms | **385 µs** | 353 µs | 1389 | **4325** |

Medians of 4 alternating runs per build. The buffered path degrades sharply past 256 connections at 16 KiB while this branch stays flat — at 16 KiB × 1024 `master` measures 20.2–21.5 ms against 374–398 µs here, consistent across every run on both sides. Note this compares two implementations, not two I/O models: `master` chunks every message through an 8 KiB buffer, and raising that buffer alone recovers much of the difference.

Only the 64-connection rows are safe to read as an axum comparison. Axum reproduces to within 1.00–1.02× there, but swings several-fold at 256, so its 1.09 ms is not meaningful. Two separate reasons: `ws_latency` splits a fixed round-trip budget across connections, leaving too few samples per connection to support a tail percentile at these depths (8 at 16 KiB × 1024, addressed in #71); and axum keeps swinging at 256 even with 500 samples each, which looks like real behaviour rather than a measurement artefact. The `master`-versus-branch gap is unaffected either way, since both sides see identical sampling. The `compio` client saturates around 1024 connections — 17–27 ms for both servers — so those rows say nothing about the server and are omitted.

## HTTP

Vectored writes let hyper keep its `Queue` strategy instead of flattening the body into its own buffer, so plain HTTP benefits too: a 1 MiB keep-alive response body goes from 73.8 µs to 58.4 µs (median of 3 runs).

<details>
<summary>Benchmark environment</summary>

- AMD Ryzen 9 9950X3D (16C/32T), 92 GiB RAM, `performance` governor
- CachyOS, Linux 7.1.6-1-cachyos x86_64, io_uring enabled
- rustc 1.97.1, release profile
- Client and server on the same host over loopback, each single-threaded
- Both pinned to one CCD (`taskset -c 0-7`). A mask spanning both CCDs makes round trips bimodal — at 16 KiB, ~9.6 µs when co-resident against ~20.7 µs across the fabric — which flips run-level p50. This affects `master` and this branch alike.
- Closed loop, one request in flight per connection: service time at a given queue depth, not response time at a target rate.
- Concurrency numbers come from the `ws_latency` benchmark in #69, with `CELLS` extended to 256 and 1024 connections; the single-connection distributions come from a standalone dumper so every round trip is recorded individually.

</details>


